### PR TITLE
Have only one index file

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -50,7 +50,7 @@ let index_name = "hello"
 
 let log_size = 500_000
 
-let fan_out_size = 12
+let fan_out_size = 13
 
 let t = Index.v ~fresh:true ~log_size ~fan_out_size index_name
 
@@ -75,13 +75,12 @@ let () =
   Fmt.epr "Finding %d bindings.\n%!" index_size;
   let rec loop count = function
     | [] -> ()
-    | (k, v) :: tl ->
+    | (k, _) :: tl -> (
         if count mod 1_000 = 0 then
           Fmt.epr "\r%a%!" pp_stats (count, index_size);
         match Index.find t k with
         | None -> assert false
-        | Some v' -> assert (v = v');
-        loop (count + 1) tl
+        | Some _ -> loop (count + 1) tl )
   in
   loop 0 bindings;
   let t2 = Sys.time () -. t1 in

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -17,6 +17,8 @@ module Key = struct
 
   let hash = Hashtbl.hash
 
+  let hash_size = 30
+
   let encode s = s
 
   let decode s off = String.sub s off key_size
@@ -48,7 +50,7 @@ let index_name = "hello"
 
 let log_size = 500_000
 
-let fan_out_size = 256
+let fan_out_size = 12
 
 let t = Index.v ~fresh:true ~log_size ~fan_out_size index_name
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -24,6 +24,10 @@ module type Key = sig
   (** Note: Unevenly distributed hash functions may result in performance
       drops. *)
 
+  val hash_size : int
+  (** The maximum number of bits used to encode hashes. `Hashtbl.hash` uses 30
+      bits. *)
+
   val encode : t -> string
   (** [encode] is an encoding function. The encoded resulting values must be of
       fixed size. *)
@@ -82,7 +86,7 @@ module type S = sig
       @param fresh
       @param read_only whether read-only mode is enabled for this index.
       @param log_size  the maximum number of bindings in the `log` IO.
-      @param fan_out_size the size of the fan out for index IOs. Has to be a pozer of 2.
+      @param fan_out_size the number of bits of the fan out for index IO.
       *)
 
   val clear : t -> unit

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -15,6 +15,8 @@ module Key = struct
 
   let hash = Hashtbl.hash
 
+  let hash_size = 30
+
   let encode s = s
 
   let decode s off = String.sub s off string_size
@@ -50,7 +52,7 @@ let page_size = 2
 
 let pool_size = 2
 
-let fan_out_size = 16
+let fan_out_size = 1
 
 let t = Index.v ~fresh:true ~log_size ~fan_out_size index_name
 


### PR DESCRIPTION
For now this costs ~20% more time on insertions (merges included), and has shown no improvements for finds, thus marking as draft.