### PR TITLE
Allow duplicate keys

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -66,7 +66,7 @@ let () =
       let count = index_size - i in
       if count mod 1_000 = 0 then Fmt.epr "\r%a%!" pp_stats (count, index_size);
       let k, v = (Key.v (), Value.v ()) in
-      Index.replace t k v;
+      Index.add t k v;
       loop ((k, v) :: bindings) (i - 1)
   in
   let bindings = loop [] index_size in
@@ -75,12 +75,14 @@ let () =
   Fmt.epr "Finding %d bindings.\n%!" index_size;
   let rec loop count = function
     | [] -> ()
-    | (k, _) :: tl -> (
+    | (k, v) :: tl -> (
         if count mod 1_000 = 0 then
           Fmt.epr "\r%a%!" pp_stats (count, index_size);
-        match Index.find t k with
-        | None -> assert false
-        | Some _ -> loop (count + 1) tl )
+        match Index.find_all t k with
+        | [] -> assert false
+        | l ->
+            assert (List.mem v l);
+            loop (count + 1) tl )
   in
   loop 0 bindings;
   let t2 = Sys.time () -. t1 in

--- a/src/index.mli
+++ b/src/index.mli
@@ -92,15 +92,15 @@ module type S = sig
   val clear : t -> unit
   (** [clear t] clears [t] so that there are no more bindings in it. *)
 
-  val find : t -> key -> value option
-  (** [find t k] is the last binding of [k] in [t], if any. *)
+  val find_all : t -> key -> value list
+  (** [find t k] are all the bindings of [k] in [t]. The order is not
+      specified *)
 
   val mem : t -> key -> bool
-  (** [mem t k] is [true] iff [k] is binded in [t]. *)
+  (** [mem t k] is [true] iff [k] is bound in [t]. *)
 
-  val replace : t -> key -> value -> unit
-  (** [replace t k v] binds [k] to [v] in [t], replacing the existing binding
-      if any. *)
+  val add : t -> key -> value -> unit
+  (** [add t k v] binds [k] to [v] in [t]. *)
 
   val iter : (key -> value -> unit) -> t -> unit
   (** Iterates over the index bindings. Order is not specified.

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -150,16 +150,16 @@ let readonly () =
 let live_tests =
   [ ("find (present)", `Quick, find_present_live);
     ("find (absent)", `Quick, find_absent_live);
-    ("replace", `Quick, replace_live)
+    ("add", `Quick, replace_live)
   ]
 
 let restart_tests =
   [ ("find (present)", `Quick, find_present_restart);
     ("find (absent)", `Quick, find_absent_restart);
-    ("replace", `Quick, replace_restart)
+    ("add", `Quick, replace_restart)
   ]
 
-let readonly_tests = [ ("replace", `Quick, readonly) ]
+let readonly_tests = [ ("add", `Quick, readonly) ]
 
 let () =
   Alcotest.run "index"


### PR DESCRIPTION
Breaking changes :
- `replace` becomes `add` since it's not replacing the old binding anymore.
- `find` becomes `find_all` since it returns all the values bound to a key.
