### PR TITLE
Improve merge speed

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -349,7 +349,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
       if v.key_hash > hash_e then log_i
       else (
         append_entry_fanout fan_out v dst_io;
-        merge_from_log fan_out log (log_i + 1) hash_e dst_io )
+        (merge_from_log [@tailcall]) fan_out log (log_i + 1) hash_e dst_io )
 
   let append_remaining_log fan_out log log_i dst_io =
     for log_i = log_i to Array.length log - 1 do
@@ -373,9 +373,9 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
         let hash_e = K.hash key_e in
         let log_i = merge_from_log fan_out log log_i hash_e dst_io in
         append_buf_fanout fan_out hash_e buf_str dst_io;
-        go index_offset log_i )
+        (go [@tailcall]) index_offset log_i )
     in
-    go 0L 0
+    (go [@tailcall]) 0L 0
 
   let merge ~witness t =
     Log.debug (fun l -> l "merge %S" t.root);


### PR DESCRIPTION
On top of https://github.com/mirage/index/pull/14.

This PR improves performances of the `merge` function, by:

- Use an array and `Array.sort` instead of a set, to sort `log_mem`
- Precompute and store keys hash, the number of calls to `K.hash` went from 114 000 000 to 8 000 000 in the bench in `bench/`
- Avoid decoding and encoding entries, only the key need to be decoded

These improvements will be even more useful if `K.hash` is slow or if encoding/decoding values is costly.

Running the bench included in `bench/` with `index_size=3_000_000` and `log_size=500_000`, before:

```
Adding 3000000 bindings.
        2999k/3000k
3000000 bindings added in 26.371166s.
Finding 3000000 bindings.
        2999k/3000k
3000000 bindings found in 34.997058s.
```

after:

```
Adding 3000000 bindings.
        2999k/3000k
3000000 bindings added in 17.265615s.
Finding 3000000 bindings.
        2999k/3000k
3000000 bindings found in 34.854301s.
```

And with `index_size=30_000_000` and `log_size=5_000_000`, before:

```
Adding 30000000 bindings.
        29999k/30000k
30000000 bindings added in 248.663870s.
Finding 30000000 bindings.
        29999k/30000k
30000000 bindings found in 415.148805s.
```

after:

```
Adding 30000000 bindings.
        29999k/30000k
30000000 bindings added in 204.781879s.
Finding 30000000 bindings.
        29999k/30000k
30000000 bindings found in 422.372018s.
```

Note that there is a lot of noise in the benchmarks.


