### PR TITLE
Remove shared argument

### DIFF
--- a/src/index.mli
+++ b/src/index.mli
@@ -74,13 +74,7 @@ module type S = sig
   type value
   (** The type for values. *)
 
-  val v :
-    ?fresh:bool ->
-    ?readonly:bool ->
-    ?shared:bool ->
-    log_size:int ->
-    string ->
-    t
+  val v : ?fresh:bool -> ?readonly:bool -> log_size:int -> string -> t
   (** The constructor for indexes.
       @param fresh
       @param read_only whether read-only mode is enabled for this index.


### PR DESCRIPTION
The `roots` table now searches by `(root, readonly)` instead of just `name`, and all instances are shared.