### PR TITLE
use pread/pwrite instead of lseek

### DIFF
--- a/src/unix/dune
+++ b/src/unix/dune
@@ -1,4 +1,5 @@
 (library
  (public_name index.unix)
  (name index_unix)
+ (c_names pread pwrite)
  (libraries unix index))

--- a/src/unix/pread.c
+++ b/src/unix/pread.c
@@ -1,0 +1,28 @@
+#include <string.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+CAMLprim value caml_pread
+(value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
+{
+  CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);
+
+  ssize_t ret;
+  size_t fd = Int_val(v_fd);
+  size_t fd_off = Int64_val(v_fd_off);
+  size_t buf_off = Long_val(v_buf_off);
+  size_t len = Long_val(v_len);
+  char iobuf[UNIX_BUFFER_SIZE];
+
+  size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
+  caml_enter_blocking_section();
+  ret = pread(fd, iobuf, numbytes, fd_off);
+  caml_leave_blocking_section();
+
+  if (ret == -1) uerror("read", Nothing);
+  memcpy(&Byte(v_buf, buf_off), iobuf, ret);
+
+  CAMLreturn(Val_long(ret));
+}

--- a/src/unix/pwrite.c
+++ b/src/unix/pwrite.c
@@ -1,0 +1,29 @@
+#include <string.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+CAMLprim value caml_pwrite
+(value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
+{
+  CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);
+
+  ssize_t ret;
+  size_t fd = Int_val(v_fd);
+  size_t fd_off = Int64_val(v_fd_off);
+  size_t buf_off = Long_val(v_buf_off);
+  size_t len = Long_val(v_len);
+  char iobuf[UNIX_BUFFER_SIZE];
+
+  size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
+  memcpy(iobuf, &Byte(v_buf, buf_off), numbytes);
+
+  caml_enter_blocking_section();
+  ret = pwrite(fd, iobuf, numbytes, fd_off);
+  caml_leave_blocking_section();
+
+  if (ret == -1) uerror("read", Nothing);
+
+  CAMLreturn(Val_long(ret));
+}


### PR DESCRIPTION
This will allow to have concurrent read/write to the file without locking it.

Before:

```
$ dune exec -- bench/main.exe
Adding 3000000 bindings.
	2999k/3000k
3000000 bindings added in 13.844343s.
Finding 3000000 bindings.
	2999k/3000k
3000000 bindings found in 27.114155s.
```

After:

```
$ dune exec -- bench/main.exe
Adding 3000000 bindings.
	2999k/3000k
3000000 bindings added in 13.672671s.
Finding 3000000 bindings.
	2999k/3000k
3000000 bindings found in 24.104619s.
```