### PR TITLE
Use an Array abstraction within the interpolation search

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -224,7 +224,8 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
           let proportion = (target_in -. low_in) /. (high_in -. low_in) in
           (* Convert fractional position to position in output space *)
           let position = low_out +. (proportion *. (high_out -. low_out)) in
-          Int64.of_float (Float.floor position)
+          let rounded = ceil (position -. 0.5) +. 0.5 in
+          Int64.of_float rounded
       end)
 
   let with_cache ~v ~clear =

--- a/src/index.ml
+++ b/src/index.ml
@@ -1,5 +1,6 @@
 module Private = struct
   module Fan = Fan
+  module Search = Search
 end
 
 module type Key = sig
@@ -80,8 +81,6 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
   type entry = { key : key; key_hash : int; value : value }
 
   let entry_size = K.encoded_size + V.encoded_size
-
-  let entry_sizef = float_of_int entry_size
 
   let entry_sizeL = Int64.of_int entry_size
 
@@ -180,6 +179,54 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
         let off = Int64.(to_int @@ sub off w.off) in
         decode_entry w.buf off
 
+  module Entry = struct
+    type t = entry
+
+    module Key = K
+    module Value = V
+
+    let to_key e = e.key
+
+    let to_value e = e.value
+  end
+
+  module IOArray = struct
+    type t = IO.t
+
+    type elt = entry
+
+    let get t i = get_entry t Int64.(mul i entry_sizeL)
+
+    let length t = Int64.(div (IO.offset t) entry_sizeL)
+  end
+
+  module Search =
+    Search.Make (Entry) (IOArray)
+      (struct
+        type t = int
+
+        module Entry = Entry
+
+        let compare : int -> int -> int = compare
+
+        let of_entry e = e.key_hash
+
+        let of_key = K.hash
+
+        let linear_interpolate ~low:(low_index, low_metric)
+            ~high:(high_index, high_metric) key_metric =
+          let low_in = float_of_int low_metric in
+          let high_in = float_of_int high_metric in
+          let target_in = float_of_int key_metric in
+          let low_out = Int64.to_float low_index in
+          let high_out = Int64.to_float high_index in
+          (* Fractional position of [target_in] along the line from [low_in] to [high_in] *)
+          let proportion = (target_in -. low_in) /. (high_in -. low_in) in
+          (* Convert fractional position to position in output space *)
+          let position = low_out +. (proportion *. (high_out -. low_out)) in
+          Int64.of_float (Float.floor position)
+      end)
+
   let with_cache ~v ~clear =
     let roots = Hashtbl.create 0 in
     let f ?(fresh = false) ?(readonly = false) ~log_size root =
@@ -232,89 +279,13 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
 
   let (`Staged v) = with_cache ~v:v_no_cache ~clear
 
-  let get_entry_iff_needed ~window io off = function
-    | Some e -> e
-    | None -> get_entry ~window io off
-
-  let look_around ~window io ~low ~high key h_key off =
-    let rec search op curr =
-      let off = op curr entry_sizeL in
-      if off < low || off > high then raise Not_found
-      else
-        let e = get_entry ~window io off in
-        let h_e = e.key_hash in
-        if h_e <> h_key then raise Not_found
-        else if K.equal e.key key then e.value
-        else search op off
-    in
-    match search Int64.add off with
-    | e -> e
-    | exception Not_found -> search Int64.sub off
-
-  let interpolation_search index key : value =
+  let interpolation_search index key =
     let hashed_key = K.hash key in
-    let low, high = Fan.search index.fan_out hashed_key in
-    let rec search steps ~window low high lowest_entry highest_entry =
-      if high < low then raise Not_found
-      else
-        let window =
-          match window with
-          | Some _ as w -> w
-          | None ->
-              let len = Int64.(add (sub high low) entry_sizeL) in
-              if len <= 4_096L then (
-                let buf = Bytes.create (Int64.to_int len) in
-                let n = IO.read index.io ~off:low buf in
-                assert (n = Bytes.length buf);
-                Some { buf; off = low } )
-              else None
-        in
-        let lowest_entry =
-          get_entry_iff_needed ~window index.io low lowest_entry
-        in
-        if high = low then
-          if K.equal lowest_entry.key key then lowest_entry.value
-          else raise Not_found
-        else
-          let lowest_hash = lowest_entry.key_hash in
-          if lowest_hash > hashed_key then raise Not_found
-          else
-            let highest_entry =
-              get_entry_iff_needed ~window index.io high highest_entry
-            in
-            let highest_hash = highest_entry.key_hash in
-            if highest_hash < hashed_key then raise Not_found
-            else
-              let lowest_hashf = float_of_int lowest_hash in
-              let highest_hashf = float_of_int highest_hash in
-              let hashed_keyf = float_of_int hashed_key in
-              let lowf = Int64.to_float low in
-              let highf = Int64.to_float high in
-              let doff =
-                floor
-                  ( (highf -. lowf)
-                  *. (hashed_keyf -. lowest_hashf)
-                  /. (highest_hashf -. lowest_hashf) )
-              in
-              let off = lowf +. doff -. mod_float doff entry_sizef in
-              let offL = Int64.of_float off in
-              let e = get_entry ~window index.io offL in
-              let hashed_e = e.key_hash in
-              if hashed_key = hashed_e then
-                if K.equal key e.key then e.value
-                else
-                  look_around ~window ~low ~high index.io key hashed_key offL
-              else if hashed_e < hashed_key then
-                (search [@tailcall]) (steps + 1) ~window
-                  (Int64.add offL entry_sizeL)
-                  high None (Some highest_entry)
-              else
-                (search [@tailcall]) (steps + 1) ~window low
-                  (Int64.sub offL entry_sizeL)
-                  (Some lowest_entry) None
+    let low_bytes, high_bytes = Fan.search index.fan_out hashed_key in
+    let low, high =
+      Int64.(div low_bytes entry_sizeL, div high_bytes entry_sizeL)
     in
-    if high < 0L then raise Not_found
-    else (search [@tailcall]) ~window:None 0 low high None None
+    Search.interpolation_search index.io key ~low ~high
 
   let sync_log t =
     let generation = IO.get_generation t.log in

--- a/src/index.mli
+++ b/src/index.mli
@@ -117,27 +117,12 @@ module type S = sig
   (** [force_merge t k v] forces a merge for [t], where [k] and [v] are any key and value of [t].  *)
 end
 
-module Private : sig
-  module Fan : sig
-    type t
-
-    val equal : t -> t -> bool
-
-    val v : hash_size:int -> entry_size:int -> int -> t
-
-    val search : t -> int -> int64 * int64
-
-    val update : t -> int -> int64 -> unit
-
-    val finalize : t -> unit
-
-    val exported_size : t -> int
-
-    val export : t -> string
-
-    val import : hash_size:int -> string -> t
-  end
-end
-
 module Make (K : Key) (V : Value) (IO : IO) :
   S with type key = K.t and type value = V.t
+
+(** These modules should not be used. They are exposed purely for testing purposes. *)
+module Private : sig
+  module Search : module type of Search
+
+  module Fan : module type of Fan
+end

--- a/src/search.ml
+++ b/src/search.ml
@@ -1,0 +1,131 @@
+module type ARRAY = sig
+  type t
+
+  type elt
+
+  val get : t -> int64 -> elt
+
+  val length : t -> int64
+end
+
+module type ENTRY = sig
+  type t
+
+  module Key : sig
+    type t
+
+    val equal : t -> t -> bool
+  end
+
+  module Value : sig
+    type t
+  end
+
+  val to_key : t -> Key.t
+
+  val to_value : t -> Value.t
+end
+
+(* Metrics must be
+    - totally ordered
+    - computable from entries and (potentially redundantly) from keys
+    - linearly interpolate-able on the int64 type *)
+module type METRIC = sig
+  type t
+
+  module Entry : ENTRY
+
+  val compare : t -> t -> int
+
+  val of_entry : Entry.t -> t
+
+  val of_key : Entry.Key.t -> t
+
+  val linear_interpolate : low:int64 * t -> high:int64 * t -> t -> int64
+end
+
+module type S = sig
+  module Entry : ENTRY
+
+  module Array : ARRAY with type elt = Entry.t
+
+  val interpolation_search :
+    Array.t -> Entry.Key.t -> low:int64 -> high:int64 -> Entry.Value.t list
+end
+
+module Make
+    (Entry : ENTRY)
+    (Array : ARRAY with type elt = Entry.t)
+    (Metric : METRIC with module Entry := Entry) :
+  S with module Entry := Entry and module Array := Array = struct
+  module Entry = Entry
+  module Array = Array
+  module Key = Entry.Key
+  module Value = Entry.Value
+
+  let look_around array (init : Value.t list) key key_metric index =
+    let rec search (op : int64 -> int64) curr acc =
+      let i = op curr in
+      if i < 0L || i >= Array.length array then acc
+      else
+        let e = array.(i) in
+        let e_metric = Metric.of_entry e in
+        if not (Metric.compare key_metric e_metric = 0) then acc
+        else
+          let new_acc =
+            if Key.equal (Entry.to_key e) key then Entry.to_value e :: acc
+            else acc
+          in
+          (search [@tailcall]) op i new_acc
+    in
+    let before = search Int64.succ index init in
+    (search [@tailcall]) Int64.pred index before
+
+  (** Improves over binary search in cases where the values in some array are
+      uniformly distributed according to some metric (such as a hash). *)
+  let interpolation_search array key ~low ~high =
+    let key_metric = Metric.of_key key in
+    (* The core of the search *)
+    let rec search low high lowest_entry highest_entry =
+      if high < low then []
+      else
+        let lowest_entry = Lazy.force lowest_entry in
+        if high = low then
+          if Key.equal (Entry.to_key lowest_entry) key then
+            [ Entry.to_value lowest_entry ]
+          else []
+        else
+          let lowest_metric = Metric.of_entry lowest_entry in
+          if Metric.compare lowest_metric key_metric > 0 then []
+          else
+            let highest_entry = Lazy.force highest_entry in
+            let highest_metric = Metric.of_entry highest_entry in
+            if Metric.compare highest_metric key_metric < 0 then []
+            else
+              let next_index =
+                Metric.linear_interpolate ~low:(low, lowest_metric)
+                  ~high:(high, highest_metric) key_metric
+              in
+              let e = array.(next_index) in
+              let e_metric = Metric.of_entry e in
+              if Metric.compare key_metric e_metric = 0 then
+                (* We have found at least one entry with the correct metric *)
+                let init =
+                  if Key.equal key (Entry.to_key e) then [ Entry.to_value e ]
+                  else []
+                in
+                look_around array init key key_metric next_index
+              else if Metric.compare key_metric e_metric > 0 then
+                (search [@tailcall])
+                  Int64.(succ next_index)
+                  high
+                  (lazy array.(Int64.(succ next_index)))
+                  (Lazy.from_val highest_entry)
+              else
+                (search [@tailcall]) low (Int64.pred next_index)
+                  (Lazy.from_val lowest_entry)
+                  (lazy array.(Int64.(pred next_index)))
+    in
+    if high < 0L then []
+    else (search [@tailcall]) low high (lazy array.(low)) (lazy array.(high))
+end

--- a/src/search.ml
+++ b/src/search.ml
@@ -101,9 +101,9 @@ module Make
     let key_metric = Metric.of_key key in
     (* The core of the search *)
     let rec search low high lowest_entry highest_entry =
-      Array.pre_fetch array ~low ~high;
       if high < low then raise Not_found
-      else
+      else (
+        Array.pre_fetch array ~low ~high;
         let lowest_entry = Lazy.force lowest_entry in
         if high = low then
           if Key.(key = Entry.to_key lowest_entry) then
@@ -135,7 +135,7 @@ module Make
               else
                 (search [@tailcall]) low (Int64.pred next_index)
                   (Lazy.from_val lowest_entry)
-                  (lazy array.(Int64.(pred next_index)))
+                  (lazy array.(Int64.(pred next_index))) )
     in
     if high < 0L then raise Not_found
     else (search [@tailcall]) low high (lazy array.(low)) (lazy array.(high))

--- a/src/search.mli
+++ b/src/search.mli
@@ -1,0 +1,56 @@
+module type ARRAY = sig
+  type t
+
+  type elt
+
+  val get : t -> int64 -> elt
+
+  val length : t -> int64
+end
+
+module type ENTRY = sig
+  type t
+
+  module Key : sig
+    type t
+
+    val equal : t -> t -> bool
+  end
+
+  module Value : sig
+    type t
+  end
+
+  val to_key : t -> Key.t
+
+  val to_value : t -> Value.t
+end
+
+module type METRIC = sig
+  type t
+
+  module Entry : ENTRY
+
+  val compare : t -> t -> int
+
+  val of_entry : Entry.t -> t
+
+  val of_key : Entry.Key.t -> t
+
+  val linear_interpolate : low:int64 * t -> high:int64 * t -> t -> int64
+end
+
+module type S = sig
+  module Entry : ENTRY
+
+  module Array : ARRAY with type elt = Entry.t
+
+  val interpolation_search :
+    Array.t -> Entry.Key.t -> low:int64 -> high:int64 -> Entry.Value.t list
+end
+
+module Make
+    (Entry : ENTRY)
+    (Array : ARRAY with type elt = Entry.t)
+    (Metric : METRIC with module Entry := Entry) :
+  S with module Entry := Entry and module Array := Array

--- a/src/search.mli
+++ b/src/search.mli
@@ -6,6 +6,8 @@ module type ARRAY = sig
   val get : t -> int64 -> elt
 
   val length : t -> int64
+
+  val pre_fetch : t -> low:int64 -> high:int64 -> unit
 end
 
 module type ENTRY = sig
@@ -46,7 +48,7 @@ module type S = sig
   module Array : ARRAY with type elt = Entry.t
 
   val interpolation_search :
-    Array.t -> Entry.Key.t -> low:int64 -> high:int64 -> Entry.Value.t list
+    Array.t -> Entry.Key.t -> low:int64 -> high:int64 -> Entry.Value.t
 end
 
 module Make

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name search)
+ (libraries index alcotest))

--- a/test/search.ml
+++ b/test/search.ml
@@ -47,7 +47,8 @@ module Metric = struct
     let proportion = (target_in -. low_in) /. (high_in -. low_in) in
     (* Convert fractional position to position in output space *)
     let position = low_out +. (proportion *. (high_out -. low_out)) in
-    Int64.of_float (Float.round position)
+    let rounded = ceil (position -. 0.5) +. 0.5 in
+    Int64.of_float rounded
 end
 
 module Search = Index.Private.Search.Make (Entry) (EltArray) (Metric)
@@ -84,10 +85,8 @@ let interpolation_duplicates () =
 
 let () =
   Alcotest.run "search"
-    [
-      ( "interpolation",
-        [
-          Alcotest.test_case "unique" `Quick interpolation_unique;
-          Alcotest.test_case "duplicates" `Quick interpolation_duplicates;
-        ] );
+    [ ( "interpolation",
+        [ Alcotest.test_case "unique" `Quick interpolation_unique;
+          Alcotest.test_case "duplicates" `Quick interpolation_duplicates
+        ] )
     ]

--- a/test/search.ml
+++ b/test/search.ml
@@ -1,0 +1,93 @@
+module Entry = struct
+  module Key = struct
+    type t = int
+
+    let equal = ( = )
+  end
+
+  module Value = struct
+    type t = string
+  end
+
+  type t = Key.t * Value.t
+
+  let to_key = fst
+
+  let to_value = snd
+end
+
+module EltArray = struct
+  type t = Entry.t array
+
+  type elt = Entry.t
+
+  let get t i = t.(Int64.to_int i)
+
+  let length t = Array.length t |> Int64.of_int
+end
+
+module Metric = struct
+  module Entry = Entry
+
+  type t = Entry.Key.t
+
+  let compare : t -> t -> int = compare
+
+  let of_entry = Entry.to_key
+
+  let of_key k = k
+
+  let linear_interpolate ~low:(low_out, low_in) ~high:(high_out, high_in) m =
+    let low_in = float_of_int low_in in
+    let high_in = float_of_int high_in in
+    let target_in = float_of_int m in
+    let low_out = Int64.to_float low_out in
+    let high_out = Int64.to_float high_out in
+    (* Fractional position of [target_in] along the line from [low_in] to [high_in] *)
+    let proportion = (target_in -. low_in) /. (high_in -. low_in) in
+    (* Convert fractional position to position in output space *)
+    let position = low_out +. (proportion *. (high_out -. low_out)) in
+    Int64.of_float (Float.round position)
+end
+
+module Search = Index.Private.Search.Make (Entry) (EltArray) (Metric)
+
+let interpolation_unique () =
+  let array =
+    List.init 10_000 (fun i -> (i, string_of_int i)) |> Array.of_list
+  in
+  let length = EltArray.length array in
+  Array.iter
+    (fun (i, v) ->
+      Search.interpolation_search array i
+        ~low:Int64.(zero)
+        ~high:Int64.(pred length)
+      |> Alcotest.(check (list string)) "" [ v ])
+    array
+
+let interpolation_duplicates () =
+  let array =
+    List.init 10_000 (fun i -> (i / 2, string_of_int i)) |> Array.of_list
+  in
+  let length = EltArray.length array in
+  let _ = Array.iter (fun (i, s) -> Printf.printf "%d, %s\n" i s) array in
+  Array.iter
+    (fun (i, _) ->
+      Search.interpolation_search array
+        ~low:Int64.(zero)
+        ~high:Int64.(pred length)
+        i
+      |> Alcotest.(check (slist string String.compare))
+           ""
+           [ string_of_int (2 * i); string_of_int ((2 * i) + 1) ])
+    array
+
+let () =
+  Alcotest.run "search"
+    [
+      ( "interpolation",
+        [
+          Alcotest.test_case "unique" `Quick interpolation_unique;
+          Alcotest.test_case "duplicates" `Quick interpolation_duplicates;
+        ] );
+    ]

--- a/test/search.ml
+++ b/test/search.ml
@@ -24,6 +24,8 @@ module EltArray = struct
   let get t i = t.(Int64.to_int i)
 
   let length t = Array.length t |> Int64.of_int
+
+  let pre_fetch _ ~low:_ ~high:_ = ()
 end
 
 module Metric = struct
@@ -63,30 +65,12 @@ let interpolation_unique () =
       Search.interpolation_search array i
         ~low:Int64.(zero)
         ~high:Int64.(pred length)
-      |> Alcotest.(check (list string)) "" [ v ])
-    array
-
-let interpolation_duplicates () =
-  let array =
-    List.init 10_000 (fun i -> (i / 2, string_of_int i)) |> Array.of_list
-  in
-  let length = EltArray.length array in
-  let _ = Array.iter (fun (i, s) -> Printf.printf "%d, %s\n" i s) array in
-  Array.iter
-    (fun (i, _) ->
-      Search.interpolation_search array
-        ~low:Int64.(zero)
-        ~high:Int64.(pred length)
-        i
-      |> Alcotest.(check (slist string String.compare))
-           ""
-           [ string_of_int (2 * i); string_of_int ((2 * i) + 1) ])
+      |> Alcotest.(check string) "" v)
     array
 
 let () =
   Alcotest.run "search"
-    [ ( "interpolation",
-        [ Alcotest.test_case "unique" `Quick interpolation_unique;
-          Alcotest.test_case "duplicates" `Quick interpolation_duplicates
-        ] )
+    [
+      ( "interpolation",
+        [ Alcotest.test_case "unique" `Quick interpolation_unique ] );
     ]


### PR DESCRIPTION
This provides the interpolation_search function with a cleaner abstraction of the underlying index as an array of elements linearly distributed according to some 'metric' (in this case, the key hash).

This simplifies the core of the interpolation search quite a bit, and allows it to be tested individually. Unfortunately, it needs rebasing over https://github.com/mirage/index/pull/39 which breaks the clean array abstraction I was going for.