### PR TITLE
Generalise IOArray on arbitrary IO / element types

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -1,5 +1,6 @@
 module Private = struct
   module Fan = Fan
+  module Io_array = Io_array
   module Search = Search
 end
 
@@ -172,90 +173,16 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
     module Key = K
     module Value = V
 
+    let encoded_size = entry_size
+
+    let decode = decode_entry
+
     let to_key e = e.key
 
     let to_value e = e.value
   end
 
-  module IOArray = struct
-    type buffer = { buf : bytes; low_off : int64; high_off : int64 }
-
-    type t = { io : IO.t; mutable buffer : buffer option }
-
-    let v io = { io; buffer = None }
-
-    let get_entry_from_io io off =
-      let buf = Bytes.create entry_size in
-      let n = IO.read io ~off buf in
-      assert (n = entry_size);
-      decode_entry buf 0
-
-    let ( -- ) = Int64.sub
-
-    let get_entry_from_buffer buf off =
-      let buf_off = Int64.(to_int @@ (off -- buf.low_off)) in
-      assert (buf_off <= Bytes.length buf.buf);
-      decode_entry buf.buf buf_off
-
-    type elt = entry
-
-    let is_in_buffer t off =
-      match t.buffer with
-      | None -> false
-      | Some b ->
-          Int64.compare off b.low_off >= 0 && Int64.compare off b.high_off <= 0
-
-    let get t i =
-      let off = Int64.(mul i entry_sizeL) in
-      match t.buffer with
-      | Some b when is_in_buffer t off -> (
-          try get_entry_from_buffer b off with _ -> assert false )
-      | _ -> get_entry_from_io t.io off
-
-    let length t = Int64.(div (IO.offset t.io) entry_sizeL)
-
-    let set_buffer t ~low ~high =
-      let range = entry_size * (1 + Int64.to_int (high -- low)) in
-      let low_off = Int64.mul low entry_sizeL in
-      let high_off = Int64.mul high entry_sizeL in
-      let buf = Bytes.create range in
-      let n = IO.read t.io ~off:low_off buf in
-      assert (n = range);
-      t.buffer <- Some { buf; low_off; high_off }
-
-    let pre_fetch t ~low ~high =
-      let range = entry_size * (1 + Int64.to_int (high -- low)) in
-      if Int64.compare low high > 0 then
-        Logs.warn (fun m ->
-            m "Requested pre-fetch region is empty: [%Ld, %Ld]" low high)
-      else if range > 4096 then
-        Logs.debug (fun m ->
-            m "Requested pre-fetch [%Ld, %Ld] is larger than 4096" low high)
-      else
-        match t.buffer with
-        | Some b ->
-            let low_buf, high_buf =
-              Int64.(div b.low_off entry_sizeL, div b.high_off entry_sizeL)
-            in
-            if low >= low_buf && high <= high_buf then
-              Logs.debug (fun m ->
-                  m
-                    "Pre-existing buffer [%Ld, %Ld] encloses requested \
-                     pre-fetch [%Ld, %Ld]"
-                    low_buf high_buf low high)
-            else (
-              Logs.debug (fun m ->
-                  m
-                    "Current buffer [%Ld, %Ld] insufficient. Prefetching in \
-                     range [%Ld, %Ld]"
-                    low_buf high_buf low high);
-              set_buffer t ~low ~high )
-        | None ->
-            Logs.debug (fun m ->
-                m "No existing buffer. Prefetching in range [%Ld, %Ld]" low
-                  high);
-            set_buffer t ~low ~high
-  end
+  module IOArray = Io_array.Make (IO) (Entry)
 
   module Search =
     Search.Make (Entry) (IOArray)

--- a/src/index.ml
+++ b/src/index.ml
@@ -69,10 +69,6 @@ let may f = function None -> () | Some bf -> f bf
 
 exception RO_not_allowed
 
-let src = Logs.Src.create "index" ~doc:"Index"
-
-module Log = (val Logs.src_log src : Logs.LOG)
-
 module Make (K : Key) (V : Value) (IO : IO) = struct
   type key = K.t
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -126,5 +126,7 @@ module Make (K : Key) (V : Value) (IO : IO) :
 module Private : sig
   module Search : module type of Search
 
+  module Io_array : module type of Io_array
+
   module Fan : module type of Fan
 end

--- a/src/io_array.ml
+++ b/src/io_array.ml
@@ -1,0 +1,105 @@
+module type ELT = sig
+  type t
+
+  val encoded_size : int
+
+  val decode : Bytes.t -> int -> t
+end
+
+module type S = sig
+  include Search.ARRAY
+
+  type io
+
+  val v : io -> t
+end
+
+module Make (IO : Io.S) (Elt : ELT) :
+  S with type io = IO.t and type elt = Elt.t = struct
+  module Elt = struct
+    include Elt
+
+    let encoded_sizeL = Int64.of_int encoded_size
+  end
+
+  type io = IO.t
+
+  type elt = Elt.t
+
+  type buffer = { buf : bytes; low_off : int64; high_off : int64 }
+
+  type t = { io : IO.t; mutable buffer : buffer option }
+
+  let v io = { io; buffer = None }
+
+  let get_entry_from_io io off =
+    let buf = Bytes.create Elt.encoded_size in
+    let n = IO.read io ~off buf in
+    assert (n = Elt.encoded_size);
+    Elt.decode buf 0
+
+  let ( -- ) = Int64.sub
+
+  let get_entry_from_buffer buf off =
+    let buf_off = Int64.(to_int @@ (off -- buf.low_off)) in
+    assert (buf_off <= Bytes.length buf.buf);
+    Elt.decode buf.buf buf_off
+
+  let is_in_buffer t off =
+    match t.buffer with
+    | None -> false
+    | Some b ->
+        Int64.compare off b.low_off >= 0 && Int64.compare off b.high_off <= 0
+
+  let get t i =
+    let off = Int64.(mul i Elt.encoded_sizeL) in
+    match t.buffer with
+    | Some b when is_in_buffer t off -> (
+        try get_entry_from_buffer b off with _ -> assert false )
+    | _ -> get_entry_from_io t.io off
+
+  let length t = Int64.(div (IO.offset t.io) Elt.encoded_sizeL)
+
+  let set_buffer t ~low ~high =
+    let range = Elt.encoded_size * (1 + Int64.to_int (high -- low)) in
+    let low_off = Int64.mul low Elt.encoded_sizeL in
+    let high_off = Int64.mul high Elt.encoded_sizeL in
+    let buf = Bytes.create range in
+    let n = IO.read t.io ~off:low_off buf in
+    assert (n = range);
+    t.buffer <- Some { buf; low_off; high_off }
+
+  let pre_fetch t ~low ~high =
+    let range = Elt.encoded_size * (1 + Int64.to_int (high -- low)) in
+    if Int64.compare low high > 0 then
+      Log.warn (fun m ->
+          m "Requested pre-fetch region is empty: [%Ld, %Ld]" low high)
+    else if range > 4096 then
+      Log.debug (fun m ->
+          m "Requested pre-fetch [%Ld, %Ld] is larger than 4096" low high)
+    else
+      match t.buffer with
+      | Some b ->
+          let low_buf, high_buf =
+            Int64.
+              ( div b.low_off Elt.encoded_sizeL,
+                div b.high_off Elt.encoded_sizeL )
+          in
+          if low >= low_buf && high <= high_buf then
+            Log.debug (fun m ->
+                m
+                  "Pre-existing buffer [%Ld, %Ld] encloses requested \
+                   pre-fetch [%Ld, %Ld]"
+                  low_buf high_buf low high)
+          else (
+            Log.debug (fun m ->
+                m
+                  "Current buffer [%Ld, %Ld] insufficient. Prefetching in \
+                   range [%Ld, %Ld]"
+                  low_buf high_buf low high);
+            set_buffer t ~low ~high )
+      | None ->
+          Log.debug (fun m ->
+              m "No existing buffer. Prefetching in range [%Ld, %Ld]" low high);
+          set_buffer t ~low ~high
+end

--- a/src/io_array.mli
+++ b/src/io_array.mli
@@ -1,0 +1,20 @@
+module type ELT = sig
+  type t
+
+  val encoded_size : int
+
+  val decode : Bytes.t -> int -> t
+end
+
+module type S = sig
+  include Search.ARRAY
+
+  type io
+
+  val v : io -> t
+end
+
+(** Takes an IO instance and wraps it in an Array interface with support for
+    prefetching sections of the array. *)
+module Make (IO : Io.S) (Elt : ELT) :
+  S with type io = IO.t and type elt = Elt.t

--- a/src/log.ml
+++ b/src/log.ml
@@ -1,0 +1,5 @@
+let src = Logs.Src.create "index" ~doc:"Index"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+include Log

--- a/src/log.mli
+++ b/src/log.mli
@@ -1,0 +1,1 @@
+include Logs.LOG

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -344,3 +344,7 @@ module IO : Index.IO = struct
 end
 
 module Make (K : Index.Key) (V : Index.Value) = Index.Make (K) (V) (IO)
+
+module Private = struct
+  module IO = IO
+end

--- a/src/unix/index_unix.mli
+++ b/src/unix/index_unix.mli
@@ -1,2 +1,7 @@
 module Make (K : Index.Key) (V : Index.Value) :
   Index.S with type key = K.t and type value = V.t
+
+(** These modules should not be used. They are exposed purely for testing purposes. *)
+module Private : sig
+  module IO : Index.IO
+end

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,3 +1,3 @@
 (tests
- (names main force_merge)
+ (names main force_merge io_array)
  (libraries index.unix alcotest fmt logs logs.fmt))

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -1,0 +1,86 @@
+module IO = Index_unix.Private.IO
+
+let ( // ) = Filename.concat
+
+let root = "_tests" // "unix.io_array"
+
+module Entry = struct
+  module Key = Common.Key
+  module Value = Common.Value
+
+  type t = Key.t * Value.t
+
+  let encoded_size = Key.encoded_size + Value.encoded_size
+
+  let decode bytes off =
+    let string = Bytes.unsafe_to_string bytes in
+    let key = Key.decode string off in
+    let value = Value.decode string (off + Key.encoded_size) in
+    (key, value)
+
+  let append_io io (key, value) =
+    let encoded_key = Key.encode key in
+    let encoded_value = Value.encode value in
+    IO.append io encoded_key;
+    IO.append io encoded_value
+end
+
+module IOArray = Index.Private.Io_array.Make (IO) (Entry)
+
+let entry = Alcotest.(pair string string)
+
+let fresh_io name =
+  IO.v ~readonly:false ~fresh:true ~generation:0L ~fan_size:0L (root // name)
+
+(* Append a random sequence of [size] keys to an IO instance and return
+   a pair of an IOArray and an equivalent in-memory array. *)
+let populate_random ~size io =
+  let rec loop acc = function
+    | 0 -> acc
+    | n ->
+        let e = (Common.Key.v (), Common.Value.v ()) in
+        Entry.append_io io e;
+        loop (e :: acc) (n - 1)
+  in
+  let mem_arr = Array.of_list (List.rev (loop [] size)) in
+  let io_arr = IOArray.v io in
+  IO.sync io;
+  (mem_arr, io_arr)
+
+(* Tests *)
+let read_sequential () =
+  let size = 1000 in
+  let io = fresh_io "read_sequential" in
+  let mem_arr, io_arr = populate_random ~size io in
+  for i = 0 to size - 1 do
+    let expected = mem_arr.(i) in
+    let actual = IOArray.get io_arr (Int64.of_int i) in
+    Alcotest.(check entry)
+      (Fmt.str "Inserted key at index %i is accessible" i)
+      expected actual
+  done
+
+let read_sequential_prefetch () =
+  let size = 1000 in
+  let io = fresh_io "read_sequential_prefetch" in
+  let mem_arr, io_arr = populate_random ~size io in
+  IOArray.pre_fetch io_arr ~low:0L ~high:999L;
+
+  (* Read the arrays backwards *)
+  for i = size - 1 to 0 do
+    let expected = mem_arr.(i) in
+    let actual = IOArray.get io_arr (Int64.of_int i) in
+    Alcotest.(check entry)
+      (Fmt.str "Inserted key at index %i is accessible" i)
+      expected actual
+  done
+
+let fresh_tests = [ ("read sequential", `Quick, read_sequential) ]
+
+let prefetch_tests = [ ("read sequential", `Quick, read_sequential_prefetch) ]
+
+let () =
+  Logs.set_level (Some Logs.Debug);
+  Logs.set_reporter (Common.reporter ());
+  Alcotest.run "index"
+    [ ("fresh tests", fresh_tests); ("prefetch tests", prefetch_tests) ]


### PR DESCRIPTION
 - extracts `IOArray` to a separate `io_array.ml` file
 - functorises `IOArray` on IO and an element type
 - adds basic tests of `IOArray` behaviour (requires exposing `Index_unix.IO` under `Private`)