### PR TITLE
Replace valid file descriptor test with a check on counter

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -224,7 +224,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
           Hashtbl.remove roots (root, false);
           raise Not_found );
         let t = Hashtbl.find roots (root, readonly) in
-        if IO.valid_fd t.log then (
+        if t.counter <> 0 then (
           Log.debug (fun l -> l "%s found in cache" root);
           t.counter <- t.counter + 1;
           if fresh then clear t;

--- a/src/io.mli
+++ b/src/io.mli
@@ -39,8 +39,6 @@ module type S = sig
 
   val close : t -> unit
 
-  val valid_fd : t -> bool
-
   type lock
 
   val lock : string -> lock

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -294,12 +294,6 @@ module IO : Index.IO = struct
           let fan_size = Raw.Fan.get_size raw in
           v ~fan_size ~offset ~version raw
 
-  let valid_fd t =
-    try
-      let _ = Unix.fstat t.raw.fd in
-      true
-    with Unix.Unix_error (Unix.EBADF, _, _) -> false
-
   type lock = Unix.file_descr
 
   let unsafe_lock op f =


### PR DESCRIPTION
Sometimes the os picks the same file descriptor, when closing and re-opening an index. It is not reliable to check if the file descriptor is still valid, to see if an index is closed or not.   

We can use the counter to check if an index is still alive. 