### PR TITLE
Add empty .mli files for tests

### DIFF
--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -2,8 +2,6 @@ open Common
 
 let index_name = Filename.concat "_tests" "unix.force_merge"
 
-let t = Index.v ~fresh:true ~log_size index_name
-
 let tbl = tbl index_name
 
 let test_find_present t =

--- a/test/unix/force_merge.mli
+++ b/test/unix/force_merge.mli
@@ -1,0 +1,1 @@
+(* left empty on purpose *)

--- a/test/unix/io_array.mli
+++ b/test/unix/io_array.mli
@@ -1,0 +1,1 @@
+(* left empty on purpose *)

--- a/test/unix/main.mli
+++ b/test/unix/main.mli
@@ -1,0 +1,1 @@
+(* left empty on purpose *)


### PR DESCRIPTION
Adds a set of empty `.mil` files for the tests, to catch any unused values.