### PR TITLE
Have only one Alcotest.run

### DIFF
--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -154,22 +154,12 @@ let readonly_and_merge () =
   loop 10;
   test_fd ()
 
-let readonly_tests =
+let tests =
   [
     ("readonly in sequence", `Quick, readonly_s);
     ("readonly interleaved", `Quick, readonly);
+    ("interleaved merge", `Quick, readonly_and_merge);
   ]
-
-let merge_tests =
-  [ ("readonly and merge interleaved", `Quick, readonly_and_merge) ]
-
-let () =
-  Common.report ();
-  Alcotest.run "index"
-    [
-      ("readonly tests", readonly_tests);
-      ("merge and readonly tests", merge_tests);
-    ]
 
 (* Unix.sleep 10 *)
 (* for `ps aux | grep force_merge` and `lsof -a -s -p pid` *)

--- a/test/unix/force_merge.mli
+++ b/test/unix/force_merge.mli
@@ -1,1 +1,1 @@
-(* left empty on purpose *)
+val tests : unit Alcotest.test_case list

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -75,11 +75,8 @@ let read_sequential_prefetch () =
       expected actual
   done
 
-let fresh_tests = [ ("read sequential", `Quick, read_sequential) ]
-
-let prefetch_tests = [ ("read sequential", `Quick, read_sequential_prefetch) ]
-
-let () =
-  Common.report ();
-  Alcotest.run "index"
-    [ ("fresh tests", fresh_tests); ("prefetch tests", prefetch_tests) ]
+let tests =
+  [
+    ("fresh", `Quick, read_sequential);
+    ("prefetch", `Quick, read_sequential_prefetch);
+  ]

--- a/test/unix/io_array.mli
+++ b/test/unix/io_array.mli
@@ -1,1 +1,1 @@
-(* left empty on purpose *)
+val tests : unit Alcotest.test_case list

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -206,7 +206,6 @@ module Close = struct
     Index.replace w1 k v;
     Hashtbl.replace tbl k v;
     Index.close w1;
-
     (* while another instance is still open, read does not fail*)
     check_equivalence w1 tbl;
     test_read_after_close w2 k tbl
@@ -237,8 +236,10 @@ end
 
 let () =
   Common.report ();
-  Alcotest.run "index"
+  Alcotest.run "index.unix"
     [
+      ("io_array", Io_array.tests);
+      ("merge", Force_merge.tests);
       ("live", Live.tests);
       ("on restart", Restart.tests);
       ("readonly", Readonly.tests);


### PR DESCRIPTION
The goal is to get a cleaner test output, and more consistent test modules, exposing a `tests` value.