### PR TITLE
Have smaller fans

### DIFF
--- a/src/fan.ml
+++ b/src/fan.ml
@@ -15,8 +15,8 @@ let log2 a = log a /. log 2.
 let v ~hash_size ~entry_size n =
   let entry_sizef = float_of_int entry_size in
   let entries_per_page = 4096. /. entry_sizef in
-  let entries_fan = float_of_int n /. (entries_per_page *. entries_per_page) in
-  let size = max 0 (int_of_float (ceil (log2 entries_fan))) in
+  let raw_nb_fans = float_of_int n /. entries_per_page in
+  let size = max 0 (int_of_float (ceil (log2 raw_nb_fans))) in
   let nb_fans = 1 lsl size in
   let shift = hash_size - size in
   { fans = Array.make nb_fans 0L; mask = (nb_fans - 1) lsl shift; shift }

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -60,7 +60,7 @@ let check_updates (fan, updates) =
 let check_fan_size (fan, size) =
   let nb_fans = Fan.nb_fans fan in
   let fan_size = size / nb_fans in
-  if fan_size * entry_size > 4096 * 4096 then
+  if fan_size * entry_size > 4096 then
     fail (Printf.sprintf "Fan size is too big: %d" fan_size)
 
 let () =


### PR DESCRIPTION
This increases the number of fans to get 4k large fans.
 
Before:
```
    2999k/3000k
3000000 bindings added in 10.507509s.
Finding 3000000 bindings.
    2999k/3000k
3000000 bindings found in 19.287851s (RW).
    2999k/3000k
3000000 bindings found in 22.156307s (RO).
```
After (30% speedup in RW mode):
```
Adding 3000000 bindings.
    2999k/3000k
3000000 bindings added in 10.506458s.
Finding 3000000 bindings.
    2999k/3000k
3000000 bindings found in 12.626557s (RW).
    2999k/3000k
3000000 bindings found in 18.202100s (RO).
```