### PR TITLE
Cleaner `force_merge` signature

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -6,7 +6,7 @@
 (executable
  (name db_bench)
  (modules db_bench)
- (libraries fmt index.unix common lmdb bigstring rresult logs logs.fmt ))
+ (libraries fmt index.unix common lmdb bigstring rresult logs logs.fmt))
 
 (alias
  (name bench)

--- a/src/index.mli
+++ b/src/index.mli
@@ -114,9 +114,8 @@ module type S = sig
   val close : t -> unit
   (** Closes the files and clears the caches of [t]. *)
 
-  val force_merge : t -> key -> value -> unit
-  (** [force_merge t k v] forces a merge for [t], where [k] and [v] are any key
-      and value of [t]. *)
+  val force_merge : t -> unit
+  (** [force_merge t] forces a merge for [t]. *)
 end
 
 module Make (K : Key) (V : Value) (IO : IO) :

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -102,7 +102,7 @@ let readonly_and_merge () =
     let k1 = Key.v () in
     let v1 = Value.v () in
     Index.replace w k1 v1;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry r1 k1 v1;
     test_one_entry r2 k1 v1;
     test_one_entry r3 k1 v1;
@@ -111,7 +111,7 @@ let readonly_and_merge () =
     let v2 = Value.v () in
     Index.replace w k2 v2;
     test_one_entry r1 k1 v1;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry r2 k2 v2;
     test_one_entry r3 k1 v1;
 
@@ -121,17 +121,17 @@ let readonly_and_merge () =
     let v3 = Value.v () in
     test_one_entry r1 k1 v1;
     Index.replace w k2 v2;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry r1 k1 v1;
     Index.replace w k3 v3;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry r3 k3 v3;
 
     let k2 = Key.v () in
     let v2 = Value.v () in
     Index.replace w k2 v2;
     test_one_entry w k2 v2;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry w k2 v2;
     test_one_entry r2 k2 v2;
     test_one_entry r3 k1 v1;
@@ -140,7 +140,7 @@ let readonly_and_merge () =
     let v2 = Value.v () in
     Index.replace w k2 v2;
     test_one_entry r2 k1 v1;
-    Index.force_merge w k1 v1;
+    Index.force_merge w;
     test_one_entry w k2 v2;
     test_one_entry r2 k2 v2;
     test_one_entry r3 k2 v2


### PR DESCRIPTION
Add a way to get the witness from the index so that it's not required in the `force_merge` signature.
`get_witness` is currently not very nice so review is appreciated.