### PR TITLE
use a toplevel buffer for reads

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -150,9 +150,9 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
       let remaining = Int64.sub max offset in
       if remaining <= 0L then ()
       else
-        let size = Stdlib.min remaining page_size in
-        let raw = Bytes.create (Int64.to_int size) in
-        let n = IO.read io ~off:offset raw in
+        let len = Int64.to_int (Stdlib.min remaining page_size) in
+        let raw = Bytes.create len in
+        let n = IO.read io ~off:offset ~len raw in
         let rec read_page page off =
           if off = n then ()
           else
@@ -338,8 +338,9 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
   (* Merge [log] with [t] into [dst_io]. [log] must be sorted by key hashes. *)
   let merge_with log index dst_io =
     let entries = 10_000 in
-    let buf = Bytes.create (entries * entry_size) in
-    let refill off = ignore (IO.read index.io ~off buf) in
+    let len = entries * entry_size in
+    let buf = Bytes.create len in
+    let refill off = ignore (IO.read index.io ~off ~len buf) in
     let index_end = IO.offset index.io in
     let fan_out = index.fan_out in
     refill 0L;
@@ -430,7 +431,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
         | None -> None
         | Some index ->
             let buf = Bytes.create entry_size in
-            let n = IO.read index.io ~off:0L buf in
+            let n = IO.read index.io ~off:0L ~len:entry_size buf in
             assert (n = entry_size);
             Some (decode_entry buf 0) )
 

--- a/src/io.mli
+++ b/src/io.mli
@@ -17,7 +17,7 @@ module type S = sig
 
   val readonly : t -> bool
 
-  val read : t -> off:int64 -> bytes -> int
+  val read : t -> off:int64 -> len:int -> bytes -> int
 
   val clear : t -> unit
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -206,9 +206,9 @@ module IO : Index.IO = struct
     t.offset <- t.offset ++ len;
     if t.offset -- t.flushed > auto_flush_limit then sync t
 
-  let read t ~off buf =
+  let read t ~off ~len buf =
     if not t.readonly then assert (t.header ++ off <= t.flushed);
-    Raw.unsafe_read t.raw ~off:(t.header ++ off) ~len:(Bytes.length buf) buf
+    Raw.unsafe_read t.raw ~off:(t.header ++ off) ~len buf
 
   let offset t = t.offset
 


### PR DESCRIPTION
spotted by @gs0510 