### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/index-bench.opam
+++ b/index-bench.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml"   {>= "4.03.0"}
-  "dune"    {build & >= "1.11.0"}
+  "dune"    {>= "1.11.0"}
   "index"
   "fmt"
   "logs"

--- a/index.opam
+++ b/index.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml"   {>= "4.03.0"}
-  "dune"    {build & >= "1.11.0"}
+  "dune"    {>= "1.11.0"}
   "fmt"
   "logs"
   "alcotest" {with-test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.