### PR TITLE
Timer merge

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -6,7 +6,7 @@
 (executable
  (name db_bench)
  (modules db_bench)
- (libraries fmt index.unix common lmdb bigstring rresult logs logs.fmt))
+ (libraries fmt index.unix common lmdb bigstring rresult logs logs.fmt metrics metrics-unix))
 
 (alias
  (name bench)

--- a/index-bench.opam
+++ b/index-bench.opam
@@ -21,6 +21,7 @@ depends: [
   "bigstring"
   "rresult"
   "lmdb"
+  "metrics"
 ]
 
 pin-depends: [

--- a/src/index.ml
+++ b/src/index.ml
@@ -4,6 +4,61 @@ module Private = struct
   module Search = Search
 end
 
+module Stats = struct
+  type t = {
+    mutable bytes_read : int;
+    mutable nb_reads : int;
+    mutable bytes_written : int;
+    mutable nb_writes : int;
+    mutable nb_merge : int;
+    mutable nb_replace : int;
+  }
+
+  let fresh_stats () =
+    {
+      bytes_read = 0;
+      nb_reads = 0;
+      bytes_written = 0;
+      nb_writes = 0;
+      nb_merge = 0;
+      nb_replace = 0;
+    }
+
+  let stats = fresh_stats ()
+
+  let reset_stats () =
+    stats.bytes_read <- 0;
+    stats.nb_reads <- 0;
+    stats.bytes_written <- 0;
+    stats.nb_writes <- 0;
+    stats.nb_merge <- 0;
+    stats.nb_replace <- 0
+
+  let get () = stats
+
+  let incr_bytes_read n = stats.bytes_read <- stats.bytes_read + n
+
+  let incr_bytes_written n = stats.bytes_written <- stats.bytes_written + n
+
+  let incr_nb_reads () = stats.nb_reads <- succ stats.nb_reads
+
+  let incr_nb_writes () = stats.nb_writes <- succ stats.nb_writes
+
+  let incr_nb_merge () = stats.nb_merge <- succ stats.nb_merge
+
+  let add_read n =
+    incr_bytes_read n;
+    incr_nb_reads ()
+
+  let add_write n =
+    incr_bytes_written n;
+    incr_nb_writes ()
+
+  let start_merge () = incr_nb_merge ()
+
+  let end_merge () = ()
+end
+
 module type Key = sig
   type t
 
@@ -410,6 +465,7 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
 
   let merge ~witness t =
     Log.debug (fun l -> l "unforced merge %S\n" t.root);
+    Stats.start_merge ();
     let log = assert_and_get t.log in
     let merge_path = merge_path t.root in
     let generation = Int64.succ t.generation in
@@ -458,7 +514,8 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
         IO.clear log.io;
         Tbl.clear log.mem;
         IO.set_generation log.io generation;
-        t.generation <- generation
+        t.generation <- generation;
+        Stats.end_merge ()
 
   let get_witness t =
     match t.log with

--- a/src/index.ml
+++ b/src/index.ml
@@ -12,7 +12,10 @@ module Stats = struct
     mutable nb_writes : int;
     mutable nb_merge : int;
     mutable nb_replace : int;
+    mutable merge_time : float;
   }
+
+  let time = ref 0.0
 
   let fresh_stats () =
     {
@@ -22,6 +25,7 @@ module Stats = struct
       nb_writes = 0;
       nb_merge = 0;
       nb_replace = 0;
+      merge_time = 0.0;
     }
 
   let stats = fresh_stats ()
@@ -32,7 +36,8 @@ module Stats = struct
     stats.bytes_written <- 0;
     stats.nb_writes <- 0;
     stats.nb_merge <- 0;
-    stats.nb_replace <- 0
+    stats.nb_replace <- 0;
+    stats.merge_time <- 0.0
 
   let get () = stats
 
@@ -54,9 +59,13 @@ module Stats = struct
     incr_bytes_written n;
     incr_nb_writes ()
 
-  let start_merge () = incr_nb_merge ()
+  (* we assume that there are no concurrent merges *)
+  let start_merge () =
+    incr_nb_merge ();
+    time := Sys.time ()
 
-  let end_merge () = ()
+  let end_merge () =
+    stats.merge_time <- Sys.time () -. !time +. stats.merge_time
 end
 
 module type Key = sig

--- a/src/index.mli
+++ b/src/index.mli
@@ -127,6 +127,26 @@ end
 module Make (K : Key) (V : Value) (IO : IO) :
   S with type key = K.t and type value = V.t
 
+(** Statistics. *)
+module Stats : sig
+  type t = {
+    mutable bytes_read : int;
+    mutable nb_reads : int;
+    mutable bytes_written : int;
+    mutable nb_writes : int;
+    mutable nb_merge : int;
+    mutable nb_replace : int;
+  }
+
+  val reset_stats : unit -> unit
+
+  val get : unit -> t
+
+  val add_read : int -> unit
+
+  val add_write : int -> unit
+end
+
 (** These modules should not be used. They are exposed purely for testing
     purposes. *)
 module Private : sig

--- a/src/index.mli
+++ b/src/index.mli
@@ -136,6 +136,7 @@ module Stats : sig
     mutable nb_writes : int;
     mutable nb_merge : int;
     mutable nb_replace : int;
+    mutable merge_time : float;
   }
 
   val reset_stats : unit -> unit

--- a/src/unix/index_unix.mli
+++ b/src/unix/index_unix.mli
@@ -6,14 +6,3 @@ module Make (K : Index.Key) (V : Index.Value) :
 module Private : sig
   module IO : Index.IO
 end
-
-type stats = {
-  mutable bytes_read : int;
-  mutable nb_reads : int;
-  mutable bytes_written : int;
-  mutable nb_writes : int;
-}
-
-val reset_stats : unit -> unit
-
-val get_stats : unit -> stats


### PR DESCRIPTION
Rebased over PR #100.
 
With the results:
```
Fill in random order
index: 2.824067 micros/op; 	 354099.247645 op/s; 	 15.934466 MB/s; 	 total time = 28.240670s.
	write amplification in bytes = 10.505701; in nb of writes = 0.000587;
	merge time = 23.098916; percentage = 0.817931;
```