### PR TITLE
IO: protect write attempt in readonly mode

### DIFF
--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -294,13 +294,15 @@ module IO : Index.IO = struct
     mkdir (Filename.dirname file);
     match Sys.file_exists file with
     | false ->
-        let x = Unix.openfile file Unix.[ O_CREAT; O_CLOEXEC; mode ] 0o644 in
-        let raw = Raw.v x in
-        Raw.Offset.set raw 0L;
-        Raw.Fan.set_size raw fan_size;
-        Raw.Version.set raw;
-        Raw.Generation.set raw generation;
-        v ~fan_size ~offset:0L ~version:current_version raw
+        if readonly then Fmt.failwith "IO.v: cannot set a readonly file"
+        else
+          let x = Unix.openfile file Unix.[ O_CREAT; O_CLOEXEC; mode ] 0o644 in
+          let raw = Raw.v x in
+          Raw.Offset.set raw 0L;
+          Raw.Fan.set_size raw fan_size;
+          Raw.Version.set raw;
+          Raw.Generation.set raw generation;
+          v ~fan_size ~offset:0L ~version:current_version raw
     | true ->
         let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; mode ] 0o644 in
         let raw = Raw.v x in


### PR DESCRIPTION
In the IO module, it looks like when a new file is created in `readonly` mode ([here](https://github.com/mirage/index/blob/master/src/unix/index_unix.ml#L278)), some [write attempts are performed](https://github.com/mirage/index/blob/master/src/unix/index_unix.ml#L299).
Here is a simple piece of code that reproduces this behaviour.

```ocaml
let _ =
  Index_unix.Private.IO.v
    ~readonly:true
    ~fresh:true
    ~generation:0L
    ~fan_size:0L
    "some_file_that_does_not_exist"
```

This PR aims to avoid the file to be created and the following bad descriptor unix error `Unix.Unix_error(Unix.EBADF, "read", "")` to be thrown by mimicking the failure raised in the [second branch](https://github.com/mirage/index/blob/master/src/unix/index_unix.ml#L308) before calling `Unix.openfile`.

