### PR TITLE
Raise the OCaml lower bound to 4.06

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"   {>= "4.03.0"}
+  "ocaml"   {>= "4.06.0"}
   "dune"    {>= "1.11.0"}
   "fmt"
   "logs"


### PR DESCRIPTION
`test/search.ml` has a dependency on `List.init`, which is only
available since `4.06.0`. Tightening this lower bound is sensible,
since the only rev-dep is `irmin`, which already has a lower bound
of `4.06.0`.