### PR TITLE
Fix readonly `v`

### DIFF
--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -199,7 +199,9 @@ module IO : Index.IO = struct
     dst.flushed <- src.flushed;
     dst.raw <- src.raw
 
-  let close t = Unix.close t.raw.fd
+  let close t =
+    if not t.readonly then Buffer.clear t.buf;
+    Unix.close t.raw.fd
 
   let auto_flush_limit = 1_000_000L
 
@@ -268,10 +270,7 @@ module IO : Index.IO = struct
   let buffers = Hashtbl.create 256
 
   let buffer file =
-    try
-      let buf = Hashtbl.find buffers file in
-      Buffer.clear buf;
-      buf
+    try Hashtbl.find buffers file
     with Not_found ->
       let buf = Buffer.create (4 * 1024) in
       Hashtbl.add buffers file buf;

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -207,6 +207,17 @@ module Readonly = struct
     Index.close rw;
     Index.close ro
 
+  let readonly_v_after_replace () =
+    let Context.{ rw; clone; _ } = Context.full_index () in
+    let k = Key.v () in
+    let v = Value.v () in
+    Index.replace rw k v;
+    let ro = clone ~readonly:true in
+    Index.close rw;
+    Index.close ro;
+    let rw = clone ~readonly:false in
+    check_index_entry rw k v
+
   let readonly_clear () =
     let Context.{ rw; tbl; clone } = Context.full_index () in
     let ro = clone ~readonly:true in
@@ -244,6 +255,7 @@ module Readonly = struct
     [
       ("add", `Quick, readonly);
       ("read after clear", `Quick, readonly_clear);
+      ("Readonly v after replace", `Quick, readonly_v_after_replace);
       ("add not allowed", `Quick, fail_readonly_add);
       ("fail read if no flush", `Quick, fail_readonly_read);
     ]


### PR DESCRIPTION
Fixes (and tests) a bug found by @icristescu: opening a RO instance clears the IO buffer of the corresponding RW instance.