### PR TITLE
Call `fsync` on `flush`

### DIFF
--- a/src/index.mli
+++ b/src/index.mli
@@ -136,8 +136,9 @@ module type S = sig
       - May not observe recent concurrent updates to the index by other
         processes. *)
 
-  val flush : t -> unit
-  (** Flushes all buffers to the supplied [IO] instance. *)
+  val flush : ?with_fsync:bool -> t -> unit
+  (** Flushes all internal buffers of the [IO] instances. If [with_fsync] is
+      [true], this also flushes the OS caches for each [IO] instance. *)
 
   val close : t -> unit
   (** Closes all resources used by [t]. *)

--- a/src/io.mli
+++ b/src/io.mli
@@ -38,7 +38,7 @@ module type S = sig
 
   val clear : ?keep_generation:bool -> t -> unit
 
-  val sync : t -> unit
+  val sync : ?with_fsync:bool -> t -> unit
 
   val version : t -> string
 

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -1,5 +1,5 @@
 (library
  (public_name index.unix)
  (name index_unix)
- (c_names pread pwrite)
+ (c_names fsync pread pwrite)
  (libraries index logs logs.threaded threads unix))

--- a/src/unix/fsync.c
+++ b/src/unix/fsync.c
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Francois Berenger, Kyushu Institute of Technology          */
+/*                                                                        */
+/*   Copyright 2018 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include "caml/unixsupport.h"
+
+#ifdef _WIN32
+#include <io.h>
+#define fsync(fd) _commit(fd)
+#else
+#define fsync(fd) fsync(fd)
+#endif
+
+CAMLprim value unix_fsync(value v)
+{
+  int ret;
+#ifdef _WIN32
+  int fd = win_CRT_fd_of_filedescr(v);
+#else
+  int fd = Int_val(v);
+#endif
+  caml_enter_blocking_section();
+  ret = fsync(fd);
+  caml_leave_blocking_section();
+  if (ret == -1) uerror("fsync", Nothing);
+  return Val_unit;
+}

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -165,7 +165,7 @@ module IO : Index.IO = struct
     buf : Buffer.t;
   }
 
-  let sync t =
+  let sync ?(with_fsync = false) t =
     if t.readonly then raise RO_not_allowed;
     let buf = Buffer.contents t.buf in
     let offset = t.offset in
@@ -176,7 +176,7 @@ module IO : Index.IO = struct
       Raw.Offset.set t.raw offset;
       assert (t.flushed ++ Int64.of_int (String.length buf) = t.header ++ offset);
       t.flushed <- offset ++ t.header );
-    Raw.fsync t.raw
+    if with_fsync then Raw.fsync t.raw
 
   let name t = t.file
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -61,6 +61,8 @@ module IO : Index.IO = struct
     external pwrite : Unix.file_descr -> int64 -> bytes -> int -> int -> int
       = "caml_pwrite"
 
+    external unix_fsync : Unix.file_descr -> unit = "unix_fsync"
+
     let really_write fd off buf =
       let rec aux fd_off buf_off len =
         let w = pwrite fd fd_off buf buf_off len in
@@ -77,6 +79,8 @@ module IO : Index.IO = struct
         else (aux [@tailcall]) (fd_off ++ Int64.of_int r) (buf_off + r) (len - r)
       in
       (aux [@tailcall]) off 0 len
+
+    let fsync t = unix_fsync t.fd
 
     let unsafe_write t ~off buf =
       let buf = Bytes.unsafe_of_string buf in
@@ -171,12 +175,13 @@ module IO : Index.IO = struct
       Raw.unsafe_write t.raw ~off:t.flushed buf;
       Raw.Offset.set t.raw offset;
       assert (t.flushed ++ Int64.of_int (String.length buf) = t.header ++ offset);
-      t.flushed <- offset ++ t.header )
+      t.flushed <- offset ++ t.header );
+    Raw.fsync t.raw
 
   let name t = t.file
 
   let rename ~src ~dst =
-    sync src;
+    sync ~with_fsync:true src;
     Unix.close dst.raw.fd;
     Unix.rename src.file dst.file;
     Buffer.clear dst.buf;


### PR DESCRIPTION
Fixes #126.
I'm not sure why this should be an option though, I feel like calling `flush` we expect the content to be... flushed. Exposing some details of our internal caches doesn't feel right to me, and I can't think of a scenario where the use calls `flush` but agrees that some data is still not written to the disk, so this PR calls `fsync` on every `flush`.
Let me know if I got something wrong about it, maybe @samoht you have some insights about it?