### PR TITLE
Do not allocate 64k bytes buffers on the thread stack

### DIFF
--- a/src/unix/pread.c
+++ b/src/unix/pread.c
@@ -14,15 +14,11 @@ CAMLprim value caml_pread
   size_t fd_off = Int64_val(v_fd_off);
   size_t buf_off = Long_val(v_buf_off);
   size_t len = Long_val(v_len);
-  char iobuf[UNIX_BUFFER_SIZE];
 
   size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
-  caml_enter_blocking_section();
-  ret = pread(fd, iobuf, numbytes, fd_off);
-  caml_leave_blocking_section();
+  ret = pread(fd, &Byte(v_buf, buf_off), numbytes, fd_off);
 
   if (ret == -1) uerror("read", Nothing);
-  memcpy(&Byte(v_buf, buf_off), iobuf, ret);
 
   CAMLreturn(Val_long(ret));
 }

--- a/src/unix/pwrite.c
+++ b/src/unix/pwrite.c
@@ -14,16 +14,11 @@ CAMLprim value caml_pwrite
   size_t fd_off = Int64_val(v_fd_off);
   size_t buf_off = Long_val(v_buf_off);
   size_t len = Long_val(v_len);
-  char iobuf[UNIX_BUFFER_SIZE];
 
   size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
-  memcpy(iobuf, &Byte(v_buf, buf_off), numbytes);
+  ret = pwrite(fd, &Byte(v_buf, buf_off), numbytes, fd_off);
 
-  caml_enter_blocking_section();
-  ret = pwrite(fd, iobuf, numbytes, fd_off);
-  caml_leave_blocking_section();
-
-  if (ret == -1) uerror("read", Nothing);
+  if (ret == -1) uerror("write", Nothing);
 
   CAMLreturn(Val_long(ret));
 }


### PR DESCRIPTION
To avoid allocating on the stack, keep the runtime lock so that OCaml objects
are not moved around.

This is needed because thread stack are very small on musl<1.1.21 (80k).

Allocating a buffer of 64k bytes on the stack means that the stack overflow
detection (`caml_c_call`) won't have enough space to allocate 32k and will
segfault: see https://github.com/ocaml/ocaml/issues/7490 for a similar bug
report.

`caml_c_call` has been properly fixed in behttps://github.com/ocaml/ocaml/pull/8670
and it also has been changed to only allocate 4k -- also solving our initial
issue with too small thread stacks (as 64+8<80).

Many thanks to @sadiqj for helping with debugging the issue.

Co-authored-by: Frédéric Bour <fred@tarides.com>