### PR TITLE
Split db benchmarks

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -6,7 +6,8 @@
 (executable
  (name db_bench)
  (modules db_bench)
- (libraries fmt index.unix common lmdb bigstring rresult logs logs.fmt))
+ (libraries fmt index.unix lmdb common bigstring rresult logs logs.fmt
+   cmdliner))
 
 (alias
  (name bench)

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -65,7 +65,7 @@ let run input =
   in
   let () =
     match input with
-    | `Find `RW | `All ->
+    | `Find `RO| `All ->
         let ro = Index.v ~readonly:true ~log_size index_name in
         let (), t3 = with_timer (fun () -> finds ro 0 bindings) in
         Index.close ro;

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -65,7 +65,7 @@ let run input =
   in
   let () =
     match input with
-    | `Find `RO| `All ->
+    | `Find `RO | `All ->
         let ro = Index.v ~readonly:true ~log_size index_name in
         let (), t3 = with_timer (fun () -> finds ro 0 bindings) in
         Index.close ro;


### PR DESCRIPTION
There's a lot of benchmarks for db!
This PR is mostly trying to separate them so they can be run individually and also moving out the lmdb benchmarks to their own file.

It is ~not~ pretty, and regex would a LOT better solution, but it is also hard :)