### PR TITLE
Load log_async on startup

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -325,25 +325,30 @@ module Make (K : Key) (V : Value) (IO : IO) = struct
         Some { io; mem }
     in
     let log_async_path = log_async_path root in
-    if (not readonly) && (not fresh) && Sys.file_exists log_async_path then
-      may
-        (fun log ->
-          let io =
-            IO.v ~fresh ~readonly ~generation:0L ~fan_size:0L log_async_path
-          in
-          let entries = Int64.div (IO.force_offset io) entry_sizeL in
-          Log.debug (fun l ->
-              l "[%s] log_async file detected. Loading %Ld entries"
-                (Filename.basename root) entries);
-          iter_io
-            (fun e ->
-              Tbl.replace log.mem e.key e.value;
-              append_key_value log.io e.key e.value)
-            io;
-          IO.sync log.io;
-          IO.clear io;
-          IO.close io)
-        log;
+    (* If we are in readonly mode, the log_async will be read during sync_log so
+       there is no need to do it here. *)
+    if (not readonly) && Sys.file_exists log_async_path then (
+      let io =
+        IO.v ~fresh ~readonly:false ~generation:0L ~fan_size:0L log_async_path
+      in
+      let entries = Int64.div (IO.offset io) entry_sizeL in
+      Log.debug (fun l ->
+          l "[%s] log_async file detected. Loading %Ld entries"
+            (Filename.basename root) entries);
+      (* If we are not in fresh mode, we move the contents of log_async to
+         log. *)
+      if not fresh then
+        may
+          (fun log ->
+            iter_io
+              (fun e ->
+                Tbl.replace log.mem e.key e.value;
+                append_key_value log.io e.key e.value)
+              io;
+            IO.sync log.io;
+            IO.clear io)
+          log;
+      IO.close io );
     let generation =
       match log with None -> 0L | Some log -> IO.get_generation log.io
     in


### PR DESCRIPTION
`log_async` was not loaded on startup, so here is a patch for this.
instead of loading it (which might cause issues on the next merge because it wouldn't be empty), I copied its data into the `log`.
The code probably requires some factoring, this is only a rough hotfix.