### PR TITLE
Wait for merge thread to finish in tests

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -691,7 +691,7 @@ module Make_private (K : Key) (V : Value) (IO : IO) = struct
           Int64.compare (IO.offset log.io) (Int64.of_int t.config.log_size) > 0)
     in
     if do_merge then
-      ignore (merge ~witness:{ key; key_hash = K.hash key; value } t)
+      ignore (merge ~witness:{ key; key_hash = K.hash key; value } t : async)
 
   let iter f t =
     let t = check_open t in

--- a/src/index.mli
+++ b/src/index.mli
@@ -160,12 +160,18 @@ module Private : sig
         recent replacements of existing values (after the last merge), this will
         hit both the new and old bindings. *)
 
-    val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> unit
+    type async
+    (** The type of asynchronous computation. *)
+
+    val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> async
     (** [force_merge t] forces a merge for [t]. Optionally, a hook can be passed
         that will be called twice:
 
         - [`Before]: immediately before merging (while holding the merge lock);
         - [`After]: immediately after merging (while holding the merge lock). *)
+
+    val await : async -> unit
+    (** Wait for an asynchronous computation to finish. *)
   end
 
   module Make (K : Key) (V : Value) (IO : IO) :

--- a/src/io.mli
+++ b/src/io.mli
@@ -76,11 +76,11 @@ module type S = sig
     val with_lock : t -> (unit -> 'a) -> 'a
   end
 
-  type async_type
+  type async
 
-  val async : (unit -> 'a) -> async_type
+  val async : (unit -> 'a) -> async
 
-  val await : async_type -> unit
+  val await : async -> unit
 
-  val return : unit -> async_type
+  val return : unit -> async
 end

--- a/src/io.mli
+++ b/src/io.mli
@@ -76,5 +76,11 @@ module type S = sig
     val with_lock : t -> (unit -> 'a) -> 'a
   end
 
-  val async : (unit -> 'a) -> unit
+  type async_type
+
+  val async : (unit -> 'a) -> async_type
+
+  val await : async_type -> unit
+
+  val return : unit -> async_type
 end

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -377,7 +377,7 @@ module IO : Index.IO = struct
         raise e
   end
 
-  type async_type = Thread.t option
+  type async = Thread.t option
 
   let async f = Some (Thread.create f ())
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -377,7 +377,13 @@ module IO : Index.IO = struct
         raise e
   end
 
-  let async f = ignore (Thread.create f ())
+  type async_type = Thread.t option
+
+  let async f = Some (Thread.create f ())
+
+  let return () = None
+
+  let await t = match t with None -> () | Some t -> ignore (Thread.join t)
 end
 
 module Make (K : Index.Key) (V : Index.Value) = Index.Make (K) (V) (IO)

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -116,3 +116,17 @@ let ignore_value (_ : Value.t) = ()
 let ignore_bool (_ : bool) = ()
 
 let ignore_index (_ : Index.t) = ()
+
+module Threads : sig
+  val with_thread : (unit -> unit) -> unit
+
+  val await : Index.async -> unit
+end = struct
+  let catch_exn = ref []
+
+  let with_thread f = try f () with exn -> catch_exn := exn :: !catch_exn
+
+  let await thread =
+    Index.await thread;
+    match !catch_exn with [] -> () | e :: _ -> raise e
+end

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -44,3 +44,9 @@ val ignore_value : Value.t -> unit
 val ignore_bool : bool -> unit
 
 val ignore_index : Index.t -> unit
+
+module Threads : sig
+  val with_thread : (unit -> unit) -> unit
+
+  val await : Index.async -> unit
+end

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -241,16 +241,6 @@ let find_while_merge () =
   Threads.await t3;
   Threads.await t4
 
-let test_fail () =
-  let { Context.rw; _ } = Context.empty_index () in
-  let w = rw in
-  let k1 = Key.v () in
-  let v1 = Value.v () in
-  Index.replace w k1 v1;
-  let f () = Alcotest.fail "test fail" in
-  let t = Index.force_merge ~hook:(before f) w in
-  Threads.join t
-
 let tests =
   [
     ("readonly in sequence", `Quick, readonly_s);
@@ -259,5 +249,4 @@ let tests =
     ("write at the end of merge", `Quick, write_after_merge);
     ("write in log_async", `Quick, replace_while_merge);
     ("find while merging", `Quick, find_while_merge);
-    ("test that should fail", `Quick, test_fail);
   ]

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -308,7 +308,10 @@ module Close = struct
         ("mem", fun () -> ignore_bool (Index.mem t k : bool));
         ("replace", fun () -> Index.replace t k v);
         ("iter", fun () -> Index.iter (fun _ _ -> ()) t);
-        ("force_merge", fun () -> Index.force_merge t);
+        ( "force_merge",
+          fun () ->
+            let thread = Index.force_merge t in
+            Index.await thread );
         ("flush", fun () -> Index.flush t);
       ]
     in


### PR DESCRIPTION
In order to prevent weird debug messages during `dune runtest`, we can wait for the merge threads to finish, before exiting a test. 

However, in `index` we do not want to wait for the merge thread to finish, and therefore some debug messages can still appear during a runtest. 

There is an issues in this PR which is that the test `test_fail` does not fail and it should. 