### PR TITLE
Build benchs with index-bench instead of index

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,22 +1,21 @@
 (executable
- (name main)
+ (public_name main)
  (modules main)
+ (package index-bench)
  (libraries fmt index.unix common cmdliner))
 
 (executable
- (name db_bench)
+ (public_name db_bench)
  (modules db_bench)
+ (package index-bench)
  (libraries fmt index.unix lmdb common bigstring rresult logs logs.fmt
    cmdliner))
 
 (alias
  (name bench)
+ (package index-bench)
  (action
   (run ./main.exe)))
-
-(alias
- (name runtest)
- (deps main.exe))
 
 (library
  (name common)


### PR DESCRIPTION
This should fix the issue described here: https://github.com/mirage/index/pull/143#issuecomment-564592608
Also, that would check that `db_bench` compiles correctly in the CI.