### PR TITLE
Extract a distinct private API for Index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Removed
+
+ - Remove `iter` and `force_merge` from `Index.S`, due to difficulties with
+   guaranteeing sensible semantics for these functions under MRSW access
+   patterns. (#147)
+
 # 1.0.1 (2019-11-29)
 
 ## Added

--- a/bench/db_bench.ml
+++ b/bench/db_bench.ml
@@ -96,7 +96,7 @@ let populate_absents ar nb_entries =
   loop 0
 
 module Index = struct
-  module Index = Index_unix.Make (Context.Key) (Context.Value)
+  module Index = Index_unix.Private.Make (Context.Key) (Context.Value)
 
   let print_results = print_results "index"
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -161,7 +161,11 @@ module Private : sig
     include S
 
     val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> unit
-    (** [force_merge t] forces a merge for [t]. *)
+    (** [force_merge t] forces a merge for [t]. Optionally, a hook can be passed
+        that will be called twice:
+
+        - [`Before]: immediately before merging (while holding the merge lock);
+        - [`After]: immediately after merging (while holding the merge lock). *)
   end
 
   module Make (K : Key) (V : Value) (IO : IO) :

--- a/src/index.mli
+++ b/src/index.mli
@@ -127,11 +127,6 @@ module type S = sig
   (** [replace t k v] binds [k] to [v] in [t], replacing any existing binding of
       [k]. *)
 
-  val iter : (key -> value -> unit) -> t -> unit
-  (** Iterates over the index bindings. Order is not specified. In case of
-      recent replacements of existing values (after the last merge), this will
-      hit both the new and old bindings. *)
-
   val flush : t -> unit
   (** Flushes all buffers to the supplied [IO] instance. *)
 
@@ -159,6 +154,11 @@ module Private : sig
 
   module type S = sig
     include S
+
+    val iter : (key -> value -> unit) -> t -> unit
+    (** Iterates over the index bindings. Order is not specified. In case of
+        recent replacements of existing values (after the last merge), this will
+        hit both the new and old bindings. *)
 
     val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> unit
     (** [force_merge t] forces a merge for [t]. Optionally, a hook can be passed

--- a/src/index.mli
+++ b/src/index.mli
@@ -65,22 +65,6 @@ module type Key = sig
   (** Formatter for keys *)
 end
 
-(** These modules should not be used. They are exposed purely for testing
-    purposes. *)
-module Private : sig
-  module Search : module type of Search
-
-  module Io_array : module type of Io_array
-
-  module Fan : module type of Fan
-
-  module Hook : sig
-    type 'a t
-
-    val v : ('a -> unit) -> 'a t
-  end
-end
-
 module Stats = Stats
 
 (** The input of [Make] for values. The same requirements as for [Key] apply. *)
@@ -148,9 +132,6 @@ module type S = sig
       recent replacements of existing values (after the last merge), this will
       hit both the new and old bindings. *)
 
-  val force_merge : ?hook:[ `After | `Before ] Private.Hook.t -> t -> unit
-  (** [force_merge t] forces a merge for [t]. *)
-
   val flush : t -> unit
   (** Flushes all buffers to the supplied [IO] instance. *)
 
@@ -160,3 +141,29 @@ end
 
 module Make (K : Key) (V : Value) (IO : IO) :
   S with type key = K.t and type value = V.t
+
+(** These modules should not be used. They are exposed purely for testing
+    purposes. *)
+module Private : sig
+  module Hook : sig
+    type 'a t
+
+    val v : ('a -> unit) -> 'a t
+  end
+
+  module Search : module type of Search
+
+  module Io_array : module type of Io_array
+
+  module Fan : module type of Fan
+
+  module type S = sig
+    include S
+
+    val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> unit
+    (** [force_merge t] forces a merge for [t]. *)
+  end
+
+  module Make (K : Key) (V : Value) (IO : IO) :
+    S with type key = K.t and type value = V.t
+end

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -384,4 +384,6 @@ module Make (K : Index.Key) (V : Index.Value) = Index.Make (K) (V) (IO)
 
 module Private = struct
   module IO = IO
+  module Make (K : Index.Key) (V : Index.Value) =
+    Index.Private.Make (K) (V) (IO)
 end

--- a/src/unix/index_unix.mli
+++ b/src/unix/index_unix.mli
@@ -22,4 +22,7 @@ module Make (K : Index.Key) (V : Index.Value) :
     purposes. *)
 module Private : sig
   module IO : Index.IO
+
+  module Make (K : Index.Key) (V : Index.Value) :
+    Index.Private.S with type key = K.t and type value = V.t
 end

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -64,7 +64,7 @@ module Value = struct
   let pp s = Fmt.fmt "%s" s
 end
 
-module Index = Index_unix.Make (Key) (Value)
+module Index = Index_unix.Private.Make (Key) (Value)
 
 module Make_context (Config : sig
   val root : string

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -16,7 +16,7 @@ module Value : sig
   val v : unit -> t
 end
 
-module Index : Index.S with type key = Key.t and type value = Value.t
+module Index : Index.Private.S with type key = Key.t and type value = Value.t
 
 (** Helper constructors for fresh pre-initialised indices *)
 module Make_context (Config : sig


### PR DESCRIPTION
This splits out a separate API for Index to be used under test. For the moment, the only difference between the two is that `force_merge` is unavailable in the public API: this will allow us to properly test concurrency properties that we don't want to make available to users (see https://github.com/mirage/index/pull/144#discussion_r356645024).

We could also choose to hide other functions, such as `iter`, which we can't give very sensible semantics to currently. I'm interested to know your opinions on this.