### PR TITLE
Add missing metrics-unix dependency

### DIFF
--- a/index-bench.opam
+++ b/index-bench.opam
@@ -23,6 +23,7 @@ depends: [
   "lmdb"
   "cmdliner"
   "metrics"
+  "metrics-unix"
 ]
 
 pin-depends: [


### PR DESCRIPTION
Left out in #100 because it did not include #146, which checks benchs builds with package `index-bench`.