### PR TITLE
Revert "Move Index.iter to Index.Private.iter"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,8 @@
 
 ## Removed
 
- - Remove `iter` and `force_merge` from `Index.S`, due to difficulties with
-   guaranteeing sensible semantics for these functions under MRSW access
-   patterns. (#147)
+ - Remove `force_merge` from `Index.S`, due to difficulties with guaranteeing
+   sensible semantics to this function under MRSW access patterns. (#147, #150)
 
 # 1.0.1 (2019-11-29)
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -70,6 +70,8 @@ module type S = sig
 
   val replace : t -> key -> value -> unit
 
+  val iter : (key -> value -> unit) -> t -> unit
+
   val flush : t -> unit
 
   val close : t -> unit
@@ -739,8 +741,6 @@ module Private = struct
 
   module type S = sig
     include S
-
-    val iter : (key -> value -> unit) -> t -> unit
 
     type async
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -127,6 +127,11 @@ module type S = sig
   (** [replace t k v] binds [k] to [v] in [t], replacing any existing binding of
       [k]. *)
 
+  val iter : (key -> value -> unit) -> t -> unit
+  (** Iterates over the index bindings. Order is not specified. In case of
+      recent replacements of existing values (after the last merge), this will
+      hit both the new and old bindings. *)
+
   val flush : t -> unit
   (** Flushes all buffers to the supplied [IO] instance. *)
 
@@ -154,11 +159,6 @@ module Private : sig
 
   module type S = sig
     include S
-
-    val iter : (key -> value -> unit) -> t -> unit
-    (** Iterates over the index bindings. Order is not specified. In case of
-        recent replacements of existing values (after the last merge), this will
-        hit both the new and old bindings. *)
 
     type async
     (** The type of asynchronous computation. *)

--- a/src/index.mli
+++ b/src/index.mli
@@ -128,9 +128,13 @@ module type S = sig
       [k]. *)
 
   val iter : (key -> value -> unit) -> t -> unit
-  (** Iterates over the index bindings. Order is not specified. In case of
-      recent replacements of existing values (after the last merge), this will
-      hit both the new and old bindings. *)
+  (** Iterates over the index bindings. Limitations:
+
+      - Order is not specified.
+      - In case of recent replacements of existing values (since the last
+        merge), this will hit both the new and old bindings.
+      - May not observe recent concurrent updates to the index by other
+        processes. *)
 
   val flush : t -> unit
   (** Flushes all buffers to the supplied [IO] instance. *)


### PR DESCRIPTION
This reverts commit b82dbf3da95c752096e6b174c66cbed7262d7233. The `iter`
API endpoint is relied upon by Irmin in order to do integrity checking,
so it can't be moved to the private API. See
https://github.com/mirage/irmin/pull/904.