### PR TITLE
Reschedule the threads during merges

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -55,7 +55,8 @@ let run input file_name =
         (bindings, [ ("write", `Float t1) ])
     | _ -> (replaces rw [] index_size, [])
   in
-  Fmt.epr "Finding %d bindings.\n%!" index_size;
+  Index.flush rw;
+  Fmt.epr "Finding %d bindings (RW instance).\n%!" index_size;
   let output_json =
     match input with
     | `Find `RW | `All ->
@@ -64,6 +65,7 @@ let run input file_name =
         [ ("read_write", `Float t2) ] @ output_json
     | _ -> output_json
   in
+  Fmt.epr "Finding %d bindings (RO instance).\n%!" index_size;
   let output_json =
     match input with
     | `Find `RO | `All ->

--- a/src/index.ml
+++ b/src/index.ml
@@ -533,6 +533,7 @@ module Make_private (K : Key) (V : Value) (IO : IO) = struct
         let key_e = K.decode buf_str 0 in
         let hash_e = K.hash key_e in
         let log_i = merge_from_log fan_out log log_i hash_e dst_io in
+        IO.yield ();
         if
           log_i >= Array.length log
           ||

--- a/src/io.mli
+++ b/src/io.mli
@@ -81,4 +81,6 @@ module type S = sig
   val await : async -> unit
 
   val return : unit -> async
+
+  val yield : unit -> unit
 end

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -376,6 +376,8 @@ module IO : Index.IO = struct
 
   let async f = Some (Thread.create f ())
 
+  let yield = Thread.yield
+
   let return () = None
 
   let await t = match t with None -> () | Some t -> Thread.join t


### PR DESCRIPTION
It reduces the latency of `replace` when a merge is ongoing.
It regularly reschedules the threads during the merges, allowing the main thread do get some CPU time, because the merging thread used to take all the resources and blocked the main thread for too long.
Tested inside `tezos-node`, new block could take 2 minutes to validate beforehands (because the merging thread was holding the ressources), now it's ~2sec