### PR TITLE
Constrain Logs to >= 0.7.0

### DIFF
--- a/index-bench.opam
+++ b/index-bench.opam
@@ -17,7 +17,7 @@ depends: [
   "dune"    {>= "1.11.0"}
   "index"
   "fmt"
-  "logs"
+  "logs"    {>= "0.7.0"}
   "bigstring"
   "rresult"
   "lmdb"


### PR DESCRIPTION
Index relies on the optional dependency `Logs_threaded`, which was
introduced in `Logs.0.7.0`.