### PR TITLE
Make transitive dependencies explicit in dune files

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -2,14 +2,14 @@
  (public_name main)
  (modules main)
  (package index-bench)
- (libraries fmt index.unix common cmdliner))
+ (libraries fmt index index.unix common cmdliner stdlib-shims yojson))
 
 (executable
  (public_name db_bench)
  (modules db_bench)
  (package index-bench)
- (libraries fmt index.unix lmdb common bigstring rresult logs logs.fmt
-   cmdliner metrics metrics-unix))
+ (libraries fmt index index.unix common bigstring rresult logs logs.fmt
+   cmdliner metrics metrics-unix lmdb stdlib-shims yojson))
 
 (alias
  (name bench)
@@ -20,4 +20,4 @@
 (library
  (name common)
  (modules common)
- (libraries index.unix logs logs.fmt yojson))
+ (libraries fmt index index.unix logs logs.fmt stdlib-shims yojson))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,4 @@
 (lang dune 1.11)
 (name index)
 (using fmt 1.1)
+(implicit_transitive_deps false)

--- a/index-bench.opam
+++ b/index-bench.opam
@@ -25,6 +25,7 @@ depends: [
   "metrics"
   "metrics-unix"
   "yojson"
+  "stdlib-shims"
 ]
 
 pin-depends: [

--- a/index.opam
+++ b/index.opam
@@ -26,6 +26,7 @@ depends: [
   "alcotest" {with-test}
   "crowbar" {with-test}
   "re" {with-test}
+  "stdlib-shims"
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
  (public_name index)
  (name index)
  (modules_without_implementation io)
- (libraries logs fmt))
+ (libraries logs fmt stdlib-shims))

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -2,4 +2,4 @@
  (public_name index.unix)
  (name index_unix)
  (c_names fsync pread pwrite)
- (libraries index logs logs.threaded threads unix))
+ (libraries fmt index logs logs.threaded threads.posix unix))

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,4 +1,4 @@
 (tests
  (names main force_merge io_array)
  (package index)
- (libraries index.unix alcotest fmt logs logs.fmt re))
+ (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims))


### PR DESCRIPTION
Having another go at this, using an explicit dependency on `stdlib-shims` to solve the "abstract `format4`" issue encountered last time (https://github.com/mirage/index/pull/142).