### PR TITLE
Extract Mutex functionality from the IO signature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,23 @@
+# Unreleased
+
+## Changed
+
+- Parameterise `Index.Make` over an arbitrary mutex implementation (and remove
+  the obligation for `IO` to provide this functionality). (#160)
+
 # 1.1.0 (2019-12-21)
 
 ## Changed
 
 - Improve the cooperativeness of the `merge` operation, allowing concurrent read
   operations to share CPU resources with ongoing merges. (#152)
-  
+
 - Improve speed of read operations for read-only instances. (#141)
 
 ## Removed
 
- - Remove `force_merge` from `Index.S`, due to difficulties with guaranteeing
-   sensible semantics to this function under MRSW access patterns. (#147, #150)
+- Remove `force_merge` from `Index.S`, due to difficulties with guaranteeing
+  sensible semantics to this function under MRSW access patterns. (#147, #150)
 
 # 1.0.1 (2019-11-29)
 

--- a/src/io.mli
+++ b/src/io.mli
@@ -62,18 +62,6 @@ module type S = sig
 
   val unlock : lock -> unit
 
-  module Mutex : sig
-    type t
-
-    val create : unit -> t
-
-    val lock : t -> unit
-
-    val unlock : t -> unit
-
-    val with_lock : t -> (unit -> 'a) -> 'a
-  end
-
   type async
 
   val async : (unit -> 'a) -> async


### PR DESCRIPTION
... and parameterise `Index.Make` over a mutex implementation directly.
Decoupling the `IO` and `Mutex` signatures is a step towards simplifying
the `IO` obligation and allows these components to be tested
independently.