### PR TITLE
Extract Thread functionality from the IO signature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## Changed
 
-- Parameterise `Index.Make` over an arbitrary mutex implementation (and remove
-  the obligation for `IO` to provide this functionality). (#160)
+- Parameterise `Index.Make` over arbitrary mutex and thread implementations
+  (and remove the obligation for `IO` to provide this functionality). (#160,
+  #161)
 
 # 1.1.0 (2019-12-21)
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -103,6 +103,27 @@ module type MUTEX = sig
       unlocks [t]. *)
 end
 
+module type THREAD = sig
+  (** Cooperative threads. *)
+
+  type t
+  (** The type of thread handles. *)
+
+  val async : (unit -> 'a) -> t
+  (** [async f] creates a new thread of control which executes [f ()] and
+      returns the corresponding thread handle. The thread terminates whenever
+      [f ()] returns a value or raises an exception. *)
+
+  val await : t -> unit
+  (** [await t] blocks on the termination of [t]. *)
+
+  val return : unit -> t
+  (** [return ()] is a pre-terminated thread handle. *)
+
+  val yield : unit -> unit
+  (** Re-schedule the calling thread without suspending it. *)
+end
+
 exception RO_not_allowed
 (** The exception raised when a write operation is attempted on a read_only
     index. *)
@@ -165,7 +186,7 @@ module type S = sig
   (** Closes all resources used by [t]. *)
 end
 
-module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) :
+module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :
   S with type key = K.t and type value = V.t
 
 (** These modules should not be used. They are exposed purely for testing
@@ -200,6 +221,6 @@ module Private : sig
     (** Wait for an asynchronous computation to finish. *)
   end
 
-  module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) :
+  module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :
     S with type key = K.t and type value = V.t
 end

--- a/src/io.mli
+++ b/src/io.mli
@@ -61,14 +61,4 @@ module type S = sig
   val lock : string -> lock
 
   val unlock : lock -> unit
-
-  type async
-
-  val async : (unit -> 'a) -> async
-
-  val await : async -> unit
-
-  val return : unit -> async
-
-  val yield : unit -> unit
 end


### PR DESCRIPTION
... and parameterise `Index.Make` over a thread implementation directly.

This is a natural extension of https://github.com/mirage/index/pull/160 (and is based on that PR for convenience). The threading implementation isn't strictly an 'IO' concern.