### PR TITLE
Add OCaml-CI status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ## Index - a platform-agnostic multi-level index
+
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Findex%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/index)
 [![Build Status](https://travis-ci.org/mirage/index.svg?branch=master)](https://travis-ci.org/mirage/index)
 
 Index is a scalable implementation of persistent indices in OCaml.


### PR DESCRIPTION
Now that https://github.com/ocurrent/ocaml-ci/pull/100 has been merged, we have access to new badges for OCaml-CI.