### PR TITLE
Clearer JSON output for benchs

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -379,10 +379,14 @@ let print_json fmt (config, results) =
       [
         ("config", config_to_yojson config);
         ( "results",
-          `Assoc
+          `List
             (List.map
                (fun (b, result) ->
-                 (b.Index.name, Benchmark.result_to_yojson result))
+                 `Assoc
+                   [
+                     ("name", `String b.Index.name);
+                     ("metrics", Benchmark.result_to_yojson result);
+                   ])
                results) );
       ]
   in


### PR DESCRIPTION
Before:
```
"results": {
    "replace_random": {
      "time": 54.639276,
      "ops_per_sec": 183018.53047979626,
      "mbs_per_sec": 7.854303237524825,
      "read_amplification_calls": 0.0007668,
      "read_amplification_size": 7.650015317777778,
      "write_amplification_calls": 0.0006388,
      "write_amplification_size": 10.454485751111111
    },
...  
}
```

After:
```
"results": [
    {
      "name": "replace_random",
      "metrics": {
        "time": 3.800000000001025e-05,
        "ops_per_sec": 2631578.9473677115,
        "mbs_per_sec": 112.93511641649916,
        "read_amplification_calls": 0.0,
        "read_amplification_size": 0.0,
        "write_amplification_calls": 0.0,
        "write_amplification_size": 0.0
      }
    },
   ...
]
```
/cc @gs0510 