### PR TITLE
Add after clear fails

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -459,7 +459,7 @@ struct
         let new_log_offset = IO.force_offset log.io in
         let add_log_entry e = add_log_entry log e in
         sync_log_async ~generation_change:(t.generation <> generation) ();
-        if t.generation <> generation then (
+        if t.generation <> generation || t.generation = 0L then (
           Log.debug (fun l ->
               l "[%s] generation has changed, reading log and index from disk"
                 (Filename.basename t.root));

--- a/src/index.ml
+++ b/src/index.ml
@@ -182,19 +182,22 @@ struct
     let t = check_open t in
     Log.debug (fun l -> l "clear %S" t.root);
     if t.config.readonly then raise RO_not_allowed;
-    t.generation <- 0L;
     Mutex.with_lock t.merge_lock (fun () ->
+        t.generation <- Int64.succ t.generation;
         let log = assert_and_get t.log in
-        IO.clear log.io;
+        IO.set_generation log.io t.generation;
+        IO.clear ~keep_generation:true log.io;
         Tbl.clear log.mem;
         may
           (fun l ->
-            IO.clear l.io;
+            IO.set_generation l.io t.generation;
+            IO.clear ~keep_generation:true l.io;
             IO.close l.io)
           t.log_async;
         may
           (fun (i : index) ->
-            IO.clear i.io;
+            IO.set_generation i.io t.generation;
+            IO.clear ~keep_generation:true i.io;
             IO.close i.io)
           t.index;
         t.index <- None;
@@ -459,16 +462,17 @@ struct
         let new_log_offset = IO.force_offset log.io in
         let add_log_entry e = add_log_entry log e in
         sync_log_async ~generation_change:(t.generation <> generation) ();
-        if t.generation <> generation || t.generation = 0L then (
+        if t.generation <> generation then (
           Log.debug (fun l ->
               l "[%s] generation has changed, reading log and index from disk"
                 (Filename.basename t.root));
+          t.generation <- generation;
           Tbl.clear log.mem;
           iter_io add_log_entry log.io;
           may (fun (i : index) -> IO.close i.io) t.index;
-          if Int64.equal generation 0L then t.index <- None
+          let index_path = index_path t.root in
+          if not (Sys.file_exists index_path) then t.index <- None
           else
-            let index_path = index_path t.root in
             let io =
               IO.v ~fresh:false ~readonly:true ~generation ~fan_size:0L
                 index_path
@@ -476,8 +480,8 @@ struct
             let fan_out =
               Fan.import ~hash_size:K.hash_size (IO.get_fanout io)
             in
-            t.index <- Some { fan_out; io };
-            t.generation <- generation )
+            if IO.offset io = 0L then t.index <- None
+            else t.index <- Some { fan_out; io } )
         else if log_offset < new_log_offset then (
           Log.debug (fun l ->
               l "[%s] new entries detected, reading log from disk"

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -133,6 +133,15 @@ module Live = struct
       tbl ();
     Index.close rw
 
+  let open_after_clear () =
+    let Context.{ clone; rw; _ } = Context.full_index () in
+    Index.clear rw;
+    let rw2 = clone ~fresh:false ~readonly:false () in
+    Alcotest.check_raises "Finding absent should raise Not_found" Not_found
+      (fun () -> Key.v () |> Index.find rw2 |> ignore_value);
+    Index.close rw2;
+    Index.close rw
+
   let tests =
     [
       ("find (present)", `Quick, find_present_live);
@@ -143,6 +152,7 @@ module Live = struct
       ("membership", `Quick, membership);
       ("clear and iter", `Quick, iter_after_clear);
       ("clear and find", `Quick, find_after_clear);
+      ("open after clear", `Quick, open_after_clear);
     ]
 end
 
@@ -227,7 +237,8 @@ module Readonly = struct
     Index.close rw;
     Index.close ro;
     let rw = clone ~readonly:false () in
-    check_index_entry rw k v
+    check_index_entry rw k v;
+    Index.close rw
 
   let readonly_clear () =
     let Context.{ rw; tbl; clone } = Context.full_index () in
@@ -262,32 +273,55 @@ module Readonly = struct
     Index.close rw;
     Index.close ro
 
-  let readonly_add_after_clear () =
-    let Context.{ rw; tbl; clone } = Context.empty_index () in
+  let readonly_add_log_before_clear () =
+    let Context.{ rw; clone; _ } = Context.empty_index () in
     let ro = clone ~readonly:true () in
     let k1, v1 = (Key.v (), Value.v ()) in
-    let k2, v2 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
-    Index.replace rw k2 v2;
     Index.flush rw;
     check_index_entry ro k1 v1;
     Index.clear rw;
-    Hashtbl.iter
-      (fun k _ ->
-        Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k)
-          Not_found (fun () -> ignore_value (Index.find ro k1)))
-      tbl;
+    Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
+      Not_found (fun () -> ignore_value (Index.find ro k1));
+    Index.close rw;
+    Index.close ro
+
+  let readonly_add_index_before_clear () =
+    let Context.{ rw; clone; _ } = Context.full_index () in
+    let ro = clone ~readonly:true () in
+    Index.clear rw;
+    let k1, v1 = (Key.v (), Value.v ()) in
+    Index.replace rw k1 v1;
+    let thread = Index.force_merge rw in
+    Index.await thread;
+    check_index_entry ro k1 v1;
+    Index.clear rw;
+    Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
+      Not_found (fun () -> ignore_value (Index.find ro k1));
+    Index.close rw;
+    Index.close ro
+
+  let readonly_add_after_clear () =
+    let Context.{ rw; clone; _ } = Context.empty_index () in
+    let ro = clone ~readonly:true () in
     let k1, v1 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
     Index.flush rw;
     check_index_entry ro k1 v1;
-    Hashtbl.iter
-      (fun k _ ->
-        Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k)
-          Not_found (fun () -> ignore_value (Index.find ro k2)))
-      tbl;
-    Index.close rw;
-    Index.close ro
+    Index.clear rw;
+    let k2, v2 = (Key.v (), Value.v ()) in
+    Index.replace rw k2 v2;
+    Index.flush rw;
+    check_index_entry ro k2 v2
+
+  let readonly_open_after_clear () =
+    let Context.{ clone; rw; _ } = Context.full_index () in
+    Index.clear rw;
+    let ro = clone ~fresh:false ~readonly:true () in
+    Alcotest.check_raises "Finding absent should raise Not_found" Not_found
+      (fun () -> Key.v () |> Index.find ro |> ignore_value);
+    Index.close ro;
+    Index.close rw
 
   let tests =
     [
@@ -296,7 +330,14 @@ module Readonly = struct
       ("Readonly v after replace", `Quick, readonly_v_after_replace);
       ("add not allowed", `Quick, fail_readonly_add);
       ("fail read if no flush", `Quick, fail_readonly_read);
+      ( "read values added in log before clear",
+        `Quick,
+        readonly_add_log_before_clear );
+      ( "read values added in index before clear",
+        `Quick,
+        readonly_add_index_before_clear );
       ("read values added after clear", `Quick, readonly_add_after_clear);
+      ("readonly open after clear", `Quick, readonly_open_after_clear);
     ]
 end
 


### PR DESCRIPTION
If generation is `0`  and a clear is called, then the values added after the clear are not detected by an RO instance. 
 
A simple fix is to always reload the log when generation is `0`. 
