### PR TITLE
io_array tries to read from a possibly empty file

### DIFF
--- a/src/io_array.ml
+++ b/src/io_array.ml
@@ -85,9 +85,11 @@ module Make (IO : Io.S) (Elt : ELT) :
     let range = Elt.encoded_size * (1 + Int64.to_int (high -- low)) in
     let low_off = Int64.mul low Elt.encoded_sizeL in
     let high_off = Int64.mul high Elt.encoded_sizeL in
-    let n = IO.read t.io ~off:low_off ~len:range buf in
-    assert (n = range);
-    t.buffer <- Some { buf; low_off; high_off }
+    if high -- low = Int64.zero then ()
+    else
+      let n = IO.read t.io ~off:low_off ~len:range buf in
+      assert (n = range);
+      t.buffer <- Some { buf; low_off; high_off }
 
   let pre_fetch t ~low ~high =
     let range = Elt.encoded_size * (1 + Int64.to_int (high -- low)) in


### PR DESCRIPTION
I'm running some [benchmarks for the layered store with an RO instance](https://github.com/icristescu/irmin/commit/2779ae93d22ce51fc512a69e2100a5cb276f05eb) and I get 
```
+1588092108us index [DEBUG] No existing buffer. Prefetching in range [0, 0]
Benchmarks for layered store: internal error, uncaught exception:
                              File "src/io_array.ml", line 89, characters 4-10: Assertion failed
```
and after adding more logs it seems that is the interpolation search that sets `low` and `high` to 0
```
+1588163729us index [DEBUG] No existing buffer. Prefetching in range [0, 0]
Benchmarks for layered store: internal error, uncaught exception:
                              Index__Io_array.Make(IO)(Elt).Io_Array("search key low 0 high 0")
```
I couldn't reproduce this with the concurrent tests in index, but it seems anyway an error that `range` is not 0 when both `low` and `high` are.