### PR TITLE
Upgrade to OCamlformat v0.14.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.14.1
+version = 0.14.2
 parse-docstrings = true
 break-infix = fit-or-vertical


### PR DESCRIPTION
- reformats the code to be compliant with OCamlformat v0.14.2
- updates the `.ocamlformat` file accordingly