### PR TITLE
Expose syscall bindings in the public API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Added `filter`, removing bindings depending on a predicate (#165)
 
+- Added `Irmin_unix.Syscalls`, a module exposing various Unix bindings for
+  interacting with file-systems.
+
 ## Changed
 
 - Parameterise `Index.Make` over arbitrary mutex and thread implementations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,15 @@
+# Unreleased
+
+## Added
+
+- Added `Index_unix.Syscalls`, a module exposing various Unix bindings for
+  interacting with file-systems.
+
 # 1.2.0 (2020-02-25)
 
 ## Added
 
 - Added `filter`, removing bindings depending on a predicate (#165)
-
-- Added `Index_unix.Syscalls`, a module exposing various Unix bindings for
-  interacting with file-systems.
 
 ## Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Added `filter`, removing bindings depending on a predicate (#165)
 
-- Added `Irmin_unix.Syscalls`, a module exposing various Unix bindings for
+- Added `Index_unix.Syscalls`, a module exposing various Unix bindings for
   interacting with file-systems.
 
 ## Changed

--- a/src/unix/fsync.c
+++ b/src/unix/fsync.c
@@ -24,7 +24,7 @@
 #define fsync(fd) fsync(fd)
 #endif
 
-CAMLprim value unix_fsync(value v)
+CAMLprim value caml_index_fsync(value v)
 {
   int ret;
 #ifdef _WIN32

--- a/src/unix/index_unix.mli
+++ b/src/unix/index_unix.mli
@@ -18,6 +18,9 @@ all copies or substantial portions of the Software. *)
 module Make (K : Index.Key) (V : Index.Value) :
   Index.S with type key = K.t and type value = V.t
 
+module Syscalls = Syscalls
+(** Bindings to Unix system calls. *)
+
 (** These modules should not be used. They are exposed purely for testing
     purposes. *)
 module Private : sig

--- a/src/unix/pread.c
+++ b/src/unix/pread.c
@@ -4,7 +4,7 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
-CAMLprim value caml_pread
+CAMLprim value caml_index_pread
 (value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
 {
   CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);

--- a/src/unix/pwrite.c
+++ b/src/unix/pwrite.c
@@ -4,7 +4,7 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
-CAMLprim value caml_pwrite
+CAMLprim value caml_index_pwrite
 (value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
 {
   CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);

--- a/src/unix/syscalls.ml
+++ b/src/unix/syscalls.ml
@@ -1,0 +1,13 @@
+external pread : Unix.file_descr -> int64 -> bytes -> int -> int -> int
+  = "caml_pread"
+
+let pread ~fd ~fd_offset ~buffer ~buffer_offset ~length =
+  pread fd fd_offset buffer buffer_offset length
+
+external pwrite : Unix.file_descr -> int64 -> bytes -> int -> int -> int
+  = "caml_pwrite"
+
+let pwrite ~fd ~fd_offset ~buffer ~buffer_offset ~length =
+  pwrite fd fd_offset buffer buffer_offset length
+
+external fsync : Unix.file_descr -> unit = "unix_fsync"

--- a/src/unix/syscalls.ml
+++ b/src/unix/syscalls.ml
@@ -1,13 +1,13 @@
 external pread : Unix.file_descr -> int64 -> bytes -> int -> int -> int
-  = "caml_pread"
+  = "caml_index_pread"
 
 let pread ~fd ~fd_offset ~buffer ~buffer_offset ~length =
   pread fd fd_offset buffer buffer_offset length
 
 external pwrite : Unix.file_descr -> int64 -> bytes -> int -> int -> int
-  = "caml_pwrite"
+  = "caml_index_pwrite"
 
 let pwrite ~fd ~fd_offset ~buffer ~buffer_offset ~length =
   pwrite fd fd_offset buffer buffer_offset length
 
-external fsync : Unix.file_descr -> unit = "unix_fsync"
+external fsync : Unix.file_descr -> unit = "caml_index_fsync"

--- a/src/unix/syscalls.mli
+++ b/src/unix/syscalls.mli
@@ -1,0 +1,29 @@
+val pread :
+  fd:Unix.file_descr ->
+  fd_offset:int64 ->
+  buffer:bytes ->
+  buffer_offset:int ->
+  length:int ->
+  int
+(** Reads up to [length] bytes from [fd] (starting at position [fd_offset]) into
+    [buffer] (starting at position [buffer_offset]). Returns the number of bytes
+    actually read. [fd]'s cursor position is unchanged. *)
+
+val pwrite :
+  fd:Unix.file_descr ->
+  fd_offset:int64 ->
+  buffer:bytes ->
+  buffer_offset:int ->
+  length:int ->
+  int
+(** Writes up to [length] bytes from [buffer] (starting at position
+    [buffer_offset]) to the file descriptor [fd] (starting at position
+    [fd_offset]). Returns the number of bytes actually written. [fd]'s cursor
+    position is unchanged. *)
+
+val fsync : Unix.file_descr -> unit
+(** Flushes all modified buffer cache pages for a given file descriptor to the
+    disk device, so that all changed information can be retrieved even if the
+    system crashes or is rebooted. This includes writing through or flushing a
+    disk cache if present. Blocks until the device reports that the transfer has
+    completed. *)


### PR DESCRIPTION
This is a step towards: https://github.com/mirage/irmin/issues/1009.