### PR TITLE
Extract Raw module

### DIFF
--- a/src/unix/index_unix.mli
+++ b/src/unix/index_unix.mli
@@ -26,6 +26,8 @@ module Syscalls = Syscalls
 module Private : sig
   module IO : Index.IO
 
+  module Raw = Raw
+
   module Make (K : Index.Key) (V : Index.Value) :
     Index.Private.S with type key = K.t and type value = V.t
 end

--- a/src/unix/raw.ml
+++ b/src/unix/raw.ml
@@ -22,9 +22,9 @@ let decode_int64 buf =
   in
   get_uint64 buf 0
 
-type t = { fd : Unix.file_descr; mutable cursor : int64 }
+type t = { fd : Unix.file_descr } [@@unboxed]
 
-let v fd = { fd; cursor = 0L }
+let v fd = { fd }
 
 let really_write fd fd_offset buffer =
   let rec aux fd_offset buffer_offset length =
@@ -56,12 +56,10 @@ let close t = Unix.close t.fd
 let unsafe_write t ~off buf =
   let buf = Bytes.unsafe_of_string buf in
   really_write t.fd off buf;
-  t.cursor <- off ++ Int64.of_int (Bytes.length buf);
   Stats.add_write (Bytes.length buf)
 
 let unsafe_read t ~off ~len buf =
   let n = really_read t.fd off len buf in
-  t.cursor <- off ++ Int64.of_int n;
   Stats.add_read n;
   n
 

--- a/src/unix/raw.ml
+++ b/src/unix/raw.ml
@@ -1,0 +1,124 @@
+let ( ++ ) = Int64.add
+
+module Stats = Index.Stats
+
+external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64u"
+
+external get_64 : string -> int -> int64 = "%caml_string_get64"
+
+external swap64 : int64 -> int64 = "%bswap_int64"
+
+let encode_int64 i =
+  let set_uint64 s off v =
+    if not Sys.big_endian then set_64 s off (swap64 v) else set_64 s off v
+  in
+  let b = Bytes.create 8 in
+  set_uint64 b 0 i;
+  Bytes.unsafe_to_string b
+
+let decode_int64 buf =
+  let get_uint64 s off =
+    if not Sys.big_endian then swap64 (get_64 s off) else get_64 s off
+  in
+  get_uint64 buf 0
+
+type t = { fd : Unix.file_descr; mutable cursor : int64 }
+
+let v fd = { fd; cursor = 0L }
+
+let really_write fd fd_offset buffer =
+  let rec aux fd_offset buffer_offset length =
+    let w = Syscalls.pwrite ~fd ~fd_offset ~buffer ~buffer_offset ~length in
+    if w = 0 || w = length then ()
+    else
+      (aux [@tailcall])
+        (fd_offset ++ Int64.of_int w)
+        (buffer_offset + w) (length - w)
+  in
+  (aux [@tailcall]) fd_offset 0 (Bytes.length buffer)
+
+let really_read fd fd_offset length buffer =
+  let rec aux fd_offset buffer_offset length =
+    let r = Syscalls.pread ~fd ~fd_offset ~buffer ~buffer_offset ~length in
+    if r = 0 then buffer_offset (* end of file *)
+    else if r = length then buffer_offset + r
+    else
+      (aux [@tailcall])
+        (fd_offset ++ Int64.of_int r)
+        (buffer_offset + r) (length - r)
+  in
+  (aux [@tailcall]) fd_offset 0 length
+
+let fsync t = Syscalls.fsync t.fd
+
+let close t = Unix.close t.fd
+
+let unsafe_write t ~off buf =
+  let buf = Bytes.unsafe_of_string buf in
+  really_write t.fd off buf;
+  t.cursor <- off ++ Int64.of_int (Bytes.length buf);
+  Stats.add_write (Bytes.length buf)
+
+let unsafe_read t ~off ~len buf =
+  let n = really_read t.fd off len buf in
+  t.cursor <- off ++ Int64.of_int n;
+  Stats.add_read n;
+  n
+
+module Offset = struct
+  let set t n =
+    let buf = encode_int64 n in
+    unsafe_write t ~off:0L buf
+
+  let get t =
+    let buf = Bytes.create 8 in
+    let n = unsafe_read t ~off:0L ~len:8 buf in
+    assert (n = 8);
+    decode_int64 (Bytes.unsafe_to_string buf)
+end
+
+module Version = struct
+  let get t =
+    let buf = Bytes.create 8 in
+    let n = unsafe_read t ~off:8L ~len:8 buf in
+    assert (n = 8);
+    Bytes.unsafe_to_string buf
+
+  let set t v = unsafe_write t ~off:8L v
+end
+
+module Generation = struct
+  let get t =
+    let buf = Bytes.create 8 in
+    let n = unsafe_read t ~off:16L ~len:8 buf in
+    assert (n = 8);
+    decode_int64 (Bytes.unsafe_to_string buf)
+
+  let set t gen =
+    let buf = encode_int64 gen in
+    unsafe_write t ~off:16L buf
+end
+
+module Fan = struct
+  let set t buf =
+    let size = encode_int64 (Int64.of_int (String.length buf)) in
+    unsafe_write t ~off:24L size;
+    if buf <> "" then unsafe_write t ~off:(24L ++ 8L) buf
+
+  let get_size t =
+    let size_buf = Bytes.create 8 in
+    let n = unsafe_read t ~off:24L ~len:8 size_buf in
+    assert (n = 8);
+    decode_int64 (Bytes.unsafe_to_string size_buf)
+
+  let set_size t size =
+    let buf = encode_int64 size in
+    unsafe_write t ~off:24L buf
+
+  let get t =
+    let size = Int64.to_int (get_size t) in
+    let buf = Bytes.create size in
+    let n = unsafe_read t ~off:(24L ++ 8L) ~len:size buf in
+    assert (n = size);
+    Bytes.unsafe_to_string buf
+end

--- a/src/unix/raw.mli
+++ b/src/unix/raw.mli
@@ -1,0 +1,51 @@
+(** [Raw] wraps a file-descriptor with an file-format used internally by Index.
+    The format contains the following header fields:
+
+    - {b offset}: a 64-bit integer, denoting the length of the file containing
+      valid data;
+    - {b version}: an 8-byte version string;
+    - {b generation}: a 64-bit integer denoting the generation number;
+    - {b fan}: a 64-bit length field, followed by a string containing that many
+      bytes. *)
+
+type t
+(** The type of [raw] file handles. *)
+
+val v : Unix.file_descr -> t
+(** Construct a [raw] value from a file descriptor. *)
+
+val unsafe_write : t -> off:int64 -> string -> unit
+
+val unsafe_read : t -> off:int64 -> len:int -> bytes -> int
+
+val fsync : t -> unit
+
+val close : t -> unit
+
+module Version : sig
+  val get : t -> string
+
+  val set : t -> string -> unit
+end
+
+module Offset : sig
+  val get : t -> int64
+
+  val set : t -> int64 -> unit
+end
+
+module Generation : sig
+  val get : t -> int64
+
+  val set : t -> int64 -> unit
+end
+
+module Fan : sig
+  val get : t -> string
+
+  val set : t -> string -> unit
+
+  val get_size : t -> int64
+
+  val set_size : t -> int64 -> unit
+end


### PR DESCRIPTION
This extracts the `Raw` module to a `raw.ml` file, and exposes it as
`Private.Raw`. This module is now identical to the one in `Irmin_pack`, so we
might as well pull it from here to stop them from diverging again in future.

Depends on https://github.com/mirage/index/pull/176.