### PR TITLE
Fail when Unix IO version number is not as expected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Added `Index_unix.Syscalls`, a module exposing various Unix bindings for
   interacting with file-systems.
 
+## Fixed
+
+- Fail when `Index_unix.IO` file version number is not as expected.
+
 # 1.2.0 (2020-02-25)
 
 ## Added


### PR DESCRIPTION
It's now no longer necessary to keep the version number as an IO field,
since it will always be equal to `current_version`.