### PR TITLE
Add missing mtime dependency to opam file

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -23,6 +23,7 @@ depends: [
   "dune"    {>= "1.11.0"}
   "fmt"
   "logs"
+  "mtime"   {>= "1.0.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "re" {with-test}


### PR DESCRIPTION
PR https://github.com/mirage/index/pull/169 added a dependency on `mtime` which is not tracked in the `opam` file. (That was actually picked up by the CI at the time, but we missed it...)