### PR TITLE
Clear + RO

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -457,7 +457,7 @@ struct
         let new_log_offset = IO.force_offset log.io in
         let add_log_entry e = add_log_entry log e in
         sync_log_async ~generation_change:(t.generation <> generation) ();
-        if t.generation <> generation then (
+        if t.generation <> generation || t.generation = 0L then (
           Log.debug (fun l ->
               l "[%s] generation has changed, reading log and index from disk"
                 (Filename.basename t.root));

--- a/src/index.ml
+++ b/src/index.ml
@@ -182,19 +182,22 @@ struct
     let t = check_open t in
     Log.debug (fun l -> l "clear %S" t.root);
     if t.config.readonly then raise RO_not_allowed;
-    t.generation <- 0L;
     Mutex.with_lock t.merge_lock (fun () ->
+        t.generation <- Int64.succ t.generation;
         let log = assert_and_get t.log in
-        IO.clear log.io;
+        IO.set_generation log.io t.generation;
+        IO.clear ~keep_generation:true log.io;
         Tbl.clear log.mem;
         may
           (fun l ->
-            IO.clear l.io;
+            IO.set_generation l.io t.generation;
+            IO.clear ~keep_generation:true l.io;
             IO.close l.io)
           t.log_async;
         may
           (fun (i : index) ->
-            IO.clear i.io;
+            IO.set_generation i.io t.generation;
+            IO.clear ~keep_generation:true i.io;
             IO.close i.io)
           t.index;
         t.index <- None;
@@ -378,14 +381,16 @@ struct
     in
     let index =
       let index_path = index_path root in
-      if Sys.file_exists index_path then (
+      if Sys.file_exists index_path then
         let io = IO.v ~fresh ~readonly ~generation ~fan_size:0L index_path in
         let entries = Int64.div (IO.offset io) entry_sizeL in
-        Log.debug (fun l ->
-            l "[%s] index file detected. Loading %Ld entries"
-              (Filename.basename root) entries);
-        let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-        Some { fan_out; io } )
+        if IO.offset io = 0L then None
+        else (
+          Log.debug (fun l ->
+              l "[%s] index file detected. Loading %Ld entries"
+                (Filename.basename root) entries);
+          let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
+          Some { fan_out; io } )
       else (
         Log.debug (fun l ->
             l "[%s] no index file detected." (Filename.basename root));
@@ -457,16 +462,17 @@ struct
         let new_log_offset = IO.force_offset log.io in
         let add_log_entry e = add_log_entry log e in
         sync_log_async ~generation_change:(t.generation <> generation) ();
-        if t.generation <> generation || t.generation = 0L then (
+        if t.generation <> generation then (
           Log.debug (fun l ->
               l "[%s] generation has changed, reading log and index from disk"
                 (Filename.basename t.root));
+          t.generation <- generation;
           Tbl.clear log.mem;
           iter_io add_log_entry log.io;
           may (fun (i : index) -> IO.close i.io) t.index;
-          if Int64.equal generation 0L then t.index <- None
+          let index_path = index_path t.root in
+          if not (Sys.file_exists index_path) then t.index <- None
           else
-            let index_path = index_path t.root in
             let io =
               IO.v ~fresh:false ~readonly:true ~generation ~fan_size:0L
                 index_path
@@ -474,8 +480,8 @@ struct
             let fan_out =
               Fan.import ~hash_size:K.hash_size (IO.get_fanout io)
             in
-            t.index <- Some { fan_out; io };
-            t.generation <- generation )
+            if IO.offset io = 0L then t.index <- None
+            else t.index <- Some { fan_out; io } )
         else if log_offset < new_log_offset then (
           Log.debug (fun l ->
               l "[%s] new entries detected, reading log from disk"

--- a/src/index.ml
+++ b/src/index.ml
@@ -792,9 +792,12 @@ struct
               may (fun lock -> IO.unlock lock) t.writer_lock ))
 
   let ro_sync t =
+    Stats.incr_nb_ro_sync ();
     let t = check_open t in
     Log.info (fun l -> l "[%s] ro_sync" (Filename.basename t.root));
     if t.config.readonly then sync_log t else raise RW_not_allowed
+
+  let ro_sync_with_timer t = Stats.ro_sync_with_timer (fun () -> ro_sync t)
 end
 
 module Make = Make_private
@@ -820,6 +823,8 @@ module Private = struct
     val await : async -> unit
 
     val replace_with_timer : ?sampling_interval:int -> t -> key -> value -> unit
+
+    val ro_sync_with_timer : t -> unit
   end
 
   module Make = Make_private

--- a/src/index.mli
+++ b/src/index.mli
@@ -128,6 +128,10 @@ exception RO_not_allowed
 (** The exception raised when a write operation is attempted on a read_only
     index. *)
 
+exception RW_not_allowed
+(** The exception is raised when a ro_sync operation is attempted on a
+    read-write index. *)
+
 exception Closed
 (** The exception raised when any operation is attempted on a closed index,
     except for [close], which is idempotent. *)
@@ -178,9 +182,7 @@ module type S = sig
 
       - Order is not specified.
       - In case of recent replacements of existing values (since the last
-        merge), this will hit both the new and old bindings.
-      - May not observe recent concurrent updates to the index by other
-        processes. *)
+        merge), this will hit both the new and old bindings. *)
 
   val flush : ?with_fsync:bool -> t -> unit
   (** Flushes all internal buffers of the [IO] instances. If [with_fsync] is
@@ -188,6 +190,10 @@ module type S = sig
 
   val close : t -> unit
   (** Closes all resources used by [t]. *)
+
+  val ro_sync : t -> unit
+  (** [ro_sync t] syncs a read-only index with the files on disk. Raises
+      [RW_not_allowed] if called by an read-write index. *)
 end
 
 module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :

--- a/src/index.mli
+++ b/src/index.mli
@@ -234,6 +234,9 @@ module Private : sig
     (** Time replace operations. The reported time is an average on an number of
         consecutive operations, which can be specified by [sampling_interval].
         If [sampling_interval] is not set, no operation is timed. *)
+
+    val ro_sync_with_timer : t -> unit
+    (** Time ro_sync operations. *)
   end
 
   module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -6,6 +6,8 @@ type t = {
   mutable nb_merge : int;
   mutable nb_replace : int;
   mutable replace_times : float list;
+  mutable nb_ro_sync : int;
+  mutable ro_sync_times : float list;
 }
 
 let fresh_stats () =
@@ -17,6 +19,8 @@ let fresh_stats () =
     nb_merge = 0;
     nb_replace = 0;
     replace_times = [];
+    nb_ro_sync = 0;
+    ro_sync_times = [];
   }
 
 let stats = fresh_stats ()
@@ -28,7 +32,9 @@ let reset_stats () =
   stats.nb_writes <- 0;
   stats.nb_merge <- 0;
   stats.nb_replace <- 0;
-  stats.replace_times <- []
+  stats.replace_times <- [];
+  stats.nb_ro_sync <- 0;
+  stats.ro_sync_times <- []
 
 let get () = stats
 
@@ -43,6 +49,8 @@ let incr_nb_writes () = stats.nb_writes <- succ stats.nb_writes
 let incr_nb_merge () = stats.nb_merge <- succ stats.nb_merge
 
 let incr_nb_replace () = stats.nb_replace <- succ stats.nb_replace
+
+let incr_nb_ro_sync () = stats.nb_ro_sync <- succ stats.nb_ro_sync
 
 let add_read n =
   incr_bytes_read n;
@@ -67,3 +75,10 @@ let end_replace ~sampling_interval =
     stats.replace_times <- average :: stats.replace_times;
     replace_timer := Mtime_clock.counter ();
     nb_replace := 0 )
+
+let ro_sync_with_timer f =
+  let timer = Mtime_clock.counter () in
+  f ();
+  let span = Mtime_clock.count timer in
+  let time = Mtime.Span.to_us span in
+  stats.ro_sync_times <- time :: stats.ro_sync_times

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -6,6 +6,8 @@ type t = {
   mutable nb_merge : int;
   mutable nb_replace : int;
   mutable replace_times : float list;
+  mutable nb_ro_sync : int;
+  mutable ro_sync_times : float list;
 }
 (** The type for stats for an index I.
 
@@ -31,6 +33,10 @@ val incr_nb_merge : unit -> unit
 
 val incr_nb_replace : unit -> unit
 
+val incr_nb_ro_sync : unit -> unit
+
 val start_replace : unit -> unit
 
 val end_replace : sampling_interval:int -> unit
+
+val ro_sync_with_timer : (unit -> unit) -> unit

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -123,6 +123,9 @@ let readonly_and_merge () =
     Index.replace w k1 v1;
     Index.flush w;
     let t1 = Index.force_merge w in
+    Index.ro_sync r1;
+    Index.ro_sync r2;
+    Index.ro_sync r3;
     test_one_entry r1 k1 v1;
     test_one_entry r2 k1 v1;
     test_one_entry r3 k1 v1;
@@ -131,6 +134,9 @@ let readonly_and_merge () =
     let v2 = Value.v () in
     Index.replace w k2 v2;
     Index.flush w;
+    Index.ro_sync r1;
+    Index.ro_sync r2;
+    Index.ro_sync r3;
     test_one_entry r1 k1 v1;
     let t2 = Index.force_merge w in
     test_one_entry r2 k2 v2;
@@ -143,10 +149,12 @@ let readonly_and_merge () =
     test_one_entry r1 k1 v1;
     Index.replace w k2 v2;
     Index.flush w;
+    Index.ro_sync r1;
     let t3 = Index.force_merge w in
     test_one_entry r1 k1 v1;
     Index.replace w k3 v3;
     Index.flush w;
+    Index.ro_sync r3;
     let t4 = Index.force_merge w in
     test_one_entry r3 k3 v3;
 
@@ -154,6 +162,8 @@ let readonly_and_merge () =
     let v2 = Value.v () in
     Index.replace w k2 v2;
     Index.flush w;
+    Index.ro_sync r2;
+    Index.ro_sync r3;
     test_one_entry w k2 v2;
     let t5 = Index.force_merge w in
     test_one_entry w k2 v2;
@@ -164,6 +174,8 @@ let readonly_and_merge () =
     let v2 = Value.v () in
     Index.replace w k2 v2;
     Index.flush w;
+    Index.ro_sync r2;
+    Index.ro_sync r3;
     test_one_entry r2 k1 v1;
     let t6 = Index.force_merge w in
     test_one_entry w k2 v2;
@@ -195,6 +207,7 @@ let write_after_merge () =
   let hook = after (fun () -> Index.replace w k2 v2) in
   let t = Index.force_merge ~hook w in
   Threads.await t;
+  Index.ro_sync r1;
   test_one_entry r1 k1 v1;
   Alcotest.check_raises (Printf.sprintf "Absent value was found: %s." k2)
     Not_found (fun () -> ignore_value (Index.find r1 k2))
@@ -214,6 +227,7 @@ let replace_while_merge () =
         test_one_entry w k2 v2)
   in
   let t = Index.force_merge ~hook w in
+  Index.ro_sync r1;
   test_one_entry r1 k1 v1;
   Threads.await t
 
@@ -250,6 +264,7 @@ let find_in_async_generation_change () =
   let f () =
     Index.replace w k1 v1;
     Index.flush w;
+    Index.ro_sync r1;
     test_one_entry r1 k1 v1
   in
   let t1 = Index.force_merge ~hook:(before f) w in
@@ -266,9 +281,11 @@ let find_in_async_same_generation () =
   let f () =
     Index.replace w k1 v1;
     Index.flush w;
+    Index.ro_sync r1;
     test_one_entry r1 k1 v1;
     Index.replace w k2 v2;
     Index.flush w;
+    Index.ro_sync r1;
     test_one_entry r1 k2 v2
   in
   let t1 = Index.force_merge ~hook:(before f) w in

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -224,6 +224,7 @@ module Readonly = struct
     let ro = clone ~readonly:true () in
     Hashtbl.iter (fun k v -> Index.replace rw k v) main.tbl;
     Index.flush rw;
+    Index.ro_sync ro;
     check_equivalence ro main.tbl;
     Index.close rw;
     Index.close ro
@@ -245,6 +246,7 @@ module Readonly = struct
     let ro = clone ~readonly:true () in
     check_equivalence ro tbl;
     Index.clear rw;
+    Index.ro_sync ro;
     Hashtbl.iter
       (fun k _ ->
         Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k)
@@ -268,6 +270,7 @@ module Readonly = struct
     let ro = clone ~readonly:true () in
     let k1, v1 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
+    Index.ro_sync ro;
     Alcotest.check_raises "Index readonly cannot read if data is not flushed."
       Not_found (fun () -> ignore_value (Index.find ro k1));
     Index.close rw;
@@ -279,8 +282,10 @@ module Readonly = struct
     let k1, v1 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
     Index.flush rw;
+    Index.ro_sync ro;
     check_index_entry ro k1 v1;
     Index.clear rw;
+    Index.ro_sync ro;
     Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
       Not_found (fun () -> ignore_value (Index.find ro k1));
     Index.close rw;
@@ -294,8 +299,10 @@ module Readonly = struct
     Index.replace rw k1 v1;
     let thread = Index.force_merge rw in
     Index.await thread;
+    Index.ro_sync ro;
     check_index_entry ro k1 v1;
     Index.clear rw;
+    Index.ro_sync ro;
     Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
       Not_found (fun () -> ignore_value (Index.find ro k1));
     Index.close rw;

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -133,6 +133,15 @@ module Live = struct
       tbl ();
     Index.close rw
 
+  let open_after_clear () =
+    let Context.{ clone; rw; _ } = Context.full_index () in
+    Index.clear rw;
+    let rw2 = clone ~fresh:false ~readonly:false () in
+    Alcotest.check_raises "Finding absent should raise Not_found" Not_found
+      (fun () -> Key.v () |> Index.find rw2 |> ignore_value);
+    Index.close rw2;
+    Index.close rw
+
   let tests =
     [
       ("find (present)", `Quick, find_present_live);
@@ -143,6 +152,7 @@ module Live = struct
       ("membership", `Quick, membership);
       ("clear and iter", `Quick, iter_after_clear);
       ("clear and find", `Quick, find_after_clear);
+      ("open after clear", `Quick, open_after_clear);
     ]
 end
 
@@ -227,7 +237,8 @@ module Readonly = struct
     Index.close rw;
     Index.close ro;
     let rw = clone ~readonly:false () in
-    check_index_entry rw k v
+    check_index_entry rw k v;
+    Index.close rw
 
   let readonly_clear () =
     let Context.{ rw; tbl; clone } = Context.full_index () in
@@ -262,32 +273,55 @@ module Readonly = struct
     Index.close rw;
     Index.close ro
 
-  let readonly_add_after_clear () =
-    let Context.{ rw; tbl; clone } = Context.empty_index () in
+  let readonly_add_log_before_clear () =
+    let Context.{ rw; clone; _ } = Context.empty_index () in
     let ro = clone ~readonly:true () in
     let k1, v1 = (Key.v (), Value.v ()) in
-    let k2, v2 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
-    Index.replace rw k2 v2;
     Index.flush rw;
     check_index_entry ro k1 v1;
     Index.clear rw;
-    Hashtbl.iter
-      (fun k _ ->
-        Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k)
-          Not_found (fun () -> ignore_value (Index.find ro k1)))
-      tbl;
+    Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
+      Not_found (fun () -> ignore_value (Index.find ro k1));
+    Index.close rw;
+    Index.close ro
+
+  let readonly_add_index_before_clear () =
+    let Context.{ rw; clone; _ } = Context.full_index () in
+    let ro = clone ~readonly:true () in
+    Index.clear rw;
+    let k1, v1 = (Key.v (), Value.v ()) in
+    Index.replace rw k1 v1;
+    let thread = Index.force_merge rw in
+    Index.await thread;
+    check_index_entry ro k1 v1;
+    Index.clear rw;
+    Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k1)
+      Not_found (fun () -> ignore_value (Index.find ro k1));
+    Index.close rw;
+    Index.close ro
+
+  let readonly_add_after_clear () =
+    let Context.{ rw; clone; _ } = Context.empty_index () in
+    let ro = clone ~readonly:true () in
     let k1, v1 = (Key.v (), Value.v ()) in
     Index.replace rw k1 v1;
     Index.flush rw;
     check_index_entry ro k1 v1;
-    Hashtbl.iter
-      (fun k _ ->
-        Alcotest.check_raises (Printf.sprintf "Found %s key after clearing." k)
-          Not_found (fun () -> ignore_value (Index.find ro k2)))
-      tbl;
-    Index.close rw;
-    Index.close ro
+    Index.clear rw;
+    let k2, v2 = (Key.v (), Value.v ()) in
+    Index.replace rw k2 v2;
+    Index.flush rw;
+    check_index_entry ro k2 v2
+
+  let readonly_open_after_clear () =
+    let Context.{ clone; rw; _ } = Context.full_index () in
+    Index.clear rw;
+    let ro = clone ~fresh:false ~readonly:true () in
+    Alcotest.check_raises "Finding absent should raise Not_found" Not_found
+      (fun () -> Key.v () |> Index.find ro |> ignore_value);
+    Index.close ro;
+    Index.close rw
 
   let tests =
     [
@@ -296,7 +330,14 @@ module Readonly = struct
       ("Readonly v after replace", `Quick, readonly_v_after_replace);
       ("add not allowed", `Quick, fail_readonly_add);
       ("fail read if no flush", `Quick, fail_readonly_read);
+      ( "read values added in log before clear",
+        `Quick,
+        readonly_add_log_before_clear );
+      ( "read values added in index before clear",
+        `Quick,
+        readonly_add_index_before_clear );
       ("read values added after clear", `Quick, readonly_add_after_clear);
+      ("readonly open after clear", `Quick, readonly_open_after_clear);
     ]
 end
 


### PR DESCRIPTION
This PR uses https://github.com/mirage/index/pull/175 and https://github.com/mirage/index/pull/168 to make sure we have tested the two together (the tests are in `test/unix/main.ml`)

We are testing that 
1. after a `clear` and an `ro_sync` the latest values are found and old values are not found;
2. after a `clear` but *before* a `ro_sync`, old values are still found by the RO. 

Scenario 2 seems to hold because either old values are in `log.mem` (which is not updated unless an explicit call to `ro_sync`)  or they are in index. But the index is only updated after a merge, which renames the merge file into index. Meaning that the RO still reads the old values from the previous version of index, until it explicitly calls `ro_sync`. 

Did I miss some cases ? 