### PR TITLE
Allow merge operations to yield to a concurrent close

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -62,13 +62,13 @@ module type MUTEX = sig
 end
 
 module type THREAD = sig
-  type t
+  type 'a t
 
-  val async : (unit -> 'a) -> t
+  val async : (unit -> 'a) -> 'a t
 
-  val await : t -> unit
+  val await : 'a t -> ('a, [ `Async_exn of exn ]) result
 
-  val return : unit -> t
+  val return : 'a -> 'a t
 
   val yield : unit -> unit
 end
@@ -118,7 +118,7 @@ module Make_private
     (Mutex : MUTEX)
     (Thread : THREAD) =
 struct
-  type async = Thread.t
+  type 'a async = 'a Thread.t
 
   let await = Thread.await
 
@@ -726,7 +726,7 @@ struct
           Int64.compare (IO.offset log.io) (Int64.of_int t.config.log_size) > 0)
     in
     if do_merge then
-      ignore (merge ~witness:{ key; key_hash = K.hash key; value } t : async)
+      ignore (merge ~witness:{ key; key_hash = K.hash key; value } t : _ async)
 
   let replace_with_timer ?sampling_interval t key value =
     if sampling_interval <> None then Stats.start_replace ();
@@ -804,7 +804,7 @@ module Private = struct
 
     val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> async
 
-    val await : async -> unit
+    val await : 'a async -> ('a, [ `Async_exn of exn ]) result
 
     val replace_with_timer : ?sampling_interval:int -> t -> key -> value -> unit
   end

--- a/src/index.mli
+++ b/src/index.mli
@@ -211,10 +211,16 @@ module Private : sig
   module type S = sig
     include S
 
-    type async
+    val close' : hook:[ `Abort_signalled ] Hook.t -> t -> unit
+    (** [`Abort_signalled]: after the cancellation signal has been sent to any
+        concurrent merge operations, but {i before} blocking on those
+        cancellations having completed. *)
+
+    type 'a async
     (** The type of asynchronous computation. *)
 
-    val force_merge : ?hook:[ `After | `Before ] Hook.t -> t -> async
+    val force_merge :
+      ?hook:[ `After | `Before ] Hook.t -> t -> [ `Completed | `Aborted ] async
     (** [force_merge t] forces a merge for [t]. Optionally, a hook can be passed
         that will be called twice:
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -106,18 +106,18 @@ end
 module type THREAD = sig
   (** Cooperative threads. *)
 
-  type t
+  type 'a t
   (** The type of thread handles. *)
 
-  val async : (unit -> 'a) -> t
+  val async : (unit -> 'a) -> 'a t
   (** [async f] creates a new thread of control which executes [f ()] and
       returns the corresponding thread handle. The thread terminates whenever
       [f ()] returns a value or raises an exception. *)
 
-  val await : t -> unit
+  val await : 'a t -> ('a, [ `Async_exn of exn ]) result
   (** [await t] blocks on the termination of [t]. *)
 
-  val return : unit -> t
+  val return : 'a -> 'a t
   (** [return ()] is a pre-terminated thread handle. *)
 
   val yield : unit -> unit
@@ -221,7 +221,7 @@ module Private : sig
         - [`Before]: immediately before merging (while holding the merge lock);
         - [`After]: immediately after merging (while holding the merge lock). *)
 
-    val await : async -> unit
+    val await : 'a async -> ('a, [ `Async_exn of exn ]) result
     (** Wait for an asynchronous computation to finish. *)
 
     val replace_with_timer : ?sampling_interval:int -> t -> key -> value -> unit

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -116,17 +116,3 @@ let ignore_value (_ : Value.t) = ()
 let ignore_bool (_ : bool) = ()
 
 let ignore_index (_ : Index.t) = ()
-
-module Threads : sig
-  val with_thread : (unit -> unit) -> unit
-
-  val await : Index.async -> unit
-end = struct
-  let catch_exn = ref []
-
-  let with_thread f = try f () with exn -> catch_exn := exn :: !catch_exn
-
-  let await thread =
-    Index.await thread;
-    match !catch_exn with [] -> () | e :: _ -> raise e
-end

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -44,9 +44,3 @@ val ignore_value : Value.t -> unit
 val ignore_bool : bool -> unit
 
 val ignore_index : Index.t -> unit
-
-module Threads : sig
-  val with_thread : (unit -> unit) -> unit
-
-  val await : Index.async -> unit
-end

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,4 +1,5 @@
 (tests
  (names main force_merge io_array)
  (package index)
- (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims))
+ (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims
+   threads.posix))

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -322,7 +322,11 @@ module Close = struct
         ( "force_merge",
           fun () ->
             let thread = Index.force_merge t in
-            Index.await thread );
+            Index.await thread |> function
+            | Ok `Completed -> ()
+            | Ok `Aborted | Error _ ->
+                Alcotest.fail
+                  "Unexpected return status from [force_merge] after close" );
         ("flush", fun () -> Index.flush t);
       ]
     in


### PR DESCRIPTION
Fix https://github.com/mirage/index/issues/180.

The change is in two parts:

1. generalise threads to return results from children;

1. implement a pre-emptable merge operation (using thread results to propagate the return status of asynchronous merges back to the parent thread).