### PR TITLE
Handle sharing of Index instances explicitly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - `sync` has to be called by the read-only instance to synchronise with the
   files on disk. (#175)
 
+- Caching of `Index` instances is now explicit: `Index.Make` requires a cache
+  implementation, and `Index.v` may be passed a cache to be used for instance
+  sharing. The default behaviour is _not_ to share instances. (#188)
+
 ## Fixed
 
 - Added values after a clear are found by read-only instances. (#168)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Index is a scalable implementation of persistent indices in OCaml.
 
 It takes an arbitrary IO implementation and user-supplied content types 
 and supplies a standard key-value interface for persistent storage. 
-Index provides instance sharing by default: 
-each OCaml run-time shares a common singleton instance.
+
+Index supports instance sharing:
+each OCaml runtime can share a common singleton instance.
 
 Index supports multiple-reader/single-writer access.
 Concurrent access is safely managed using lock files.

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -162,7 +162,8 @@ let absent_bindings_pool = ref [||]
 let sorted_bindings_pool = ref [||]
 
 module Index = struct
-  module Index = Index_unix.Private.Make (Context.Key) (Context.Value)
+  module Index =
+    Index_unix.Private.Make (Context.Key) (Context.Value) (Index.Cache.Noop)
 
   let add_metrics =
     let no_tags x = x in
@@ -222,7 +223,10 @@ module Index = struct
     read_absent ~with_metrics !absent_bindings_pool t
 
   let run ~with_metrics ~nb_entries ~log_size ~root ~name ~fresh ~readonly b =
-    let index = Index.v ~fresh ~readonly ~log_size (root // name) in
+    let index =
+      Index.v ~cache:(Index.empty_cache ()) ~fresh ~readonly ~log_size
+        (root // name)
+    in
     let result = Benchmark.run ~nb_entries (b ~with_metrics index) in
     Index.close index;
     result

--- a/index.opam
+++ b/index.opam
@@ -35,8 +35,8 @@ Index is a scalable implementation of persistent indices in OCaml.
 
 It takes an arbitrary IO implementation and user-supplied content
 types and supplies a standard key-value interface for persistent
-storage. Index provides instance sharing by default: each OCaml
-run-time shares a common singleton instance.
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
 
 Index supports multiple-reader/single-writer access. Concurrent access
 is safely managed using lock files."""

--- a/src/index.ml
+++ b/src/index.ml
@@ -17,6 +17,7 @@ all copies or substantial portions of the Software. *)
 
 include Index_intf
 module Stats = Stats
+module Cache = Cache
 
 let may f = function None -> () | Some bf -> f bf
 
@@ -33,7 +34,8 @@ module Make_private
     (V : Value)
     (IO : Io.S)
     (Mutex : MUTEX)
-    (Thread : THREAD) =
+    (Thread : THREAD)
+    (Cache : Cache.S) =
 struct
   type 'a async = 'a Thread.t
 
@@ -294,40 +296,6 @@ struct
           no_changes ()
         else no_changes ()
 
-  let with_cache ~v ~clear =
-    let roots = Hashtbl.create 0 in
-    let f ?auto_flush_callback ?(fresh = false) ?(readonly = false) ~log_size
-        root =
-      Log.info (fun l ->
-          l "[%s] v fresh=%b readonly=%b log_size=%d" (Filename.basename root)
-            fresh readonly log_size);
-      try
-        if not (Sys.file_exists (index_dir root)) then (
-          Log.debug (fun l ->
-              l "[%s] does not exist anymore, cleaning up the fd cache"
-                (Filename.basename root));
-          Hashtbl.remove roots (root, true);
-          Hashtbl.remove roots (root, false);
-          raise Not_found);
-        let t = Hashtbl.find roots (root, readonly) in
-        if t.open_instances <> 0 then (
-          Log.debug (fun l -> l "[%s] found in cache" (Filename.basename root));
-          t.open_instances <- t.open_instances + 1;
-          if readonly then sync_log t;
-          let t = ref (Some t) in
-          if fresh then clear t;
-          t)
-        else (
-          Hashtbl.remove roots (root, readonly);
-          raise Not_found)
-      with Not_found ->
-        let instance = v ?auto_flush_callback ~fresh ~readonly ~log_size root in
-        Hashtbl.add roots (root, readonly) instance;
-        if readonly then sync_log instance;
-        ref (Some instance)
-    in
-    `Staged f
-
   let v_no_cache ?auto_flush_callback ~fresh ~readonly ~log_size root =
     Log.debug (fun l ->
         l "[%s] not found in cache, creating a new instance"
@@ -415,7 +383,47 @@ struct
       pending_cancel = false;
     }
 
-  let (`Staged v) = with_cache ~v:v_no_cache ~clear
+  type cache = (string * bool, instance) Cache.t
+
+  let empty_cache = Cache.create
+
+  let v ?(auto_flush_callback = Fun.id) ?(cache = empty_cache ())
+      ?(fresh = false) ?(readonly = false) ~log_size root =
+    let new_instance () =
+      let instance =
+        v_no_cache ~auto_flush_callback ~fresh ~readonly ~log_size root
+      in
+      if readonly then sync_log instance;
+      Cache.add cache (root, readonly) instance;
+      ref (Some instance)
+    in
+    Log.info (fun l ->
+        l "[%s] v fresh=%b readonly=%b log_size=%d" (Filename.basename root)
+          fresh readonly log_size);
+    match
+      (Cache.find cache (root, readonly), Sys.file_exists (index_dir root))
+    with
+    | None, _ -> new_instance ()
+    | Some _, false ->
+        Log.debug (fun l ->
+            l "[%s] does not exist anymore, cleaning up the fd cache"
+              (Filename.basename root));
+        Cache.remove cache (root, true);
+        Cache.remove cache (root, false);
+        new_instance ()
+    | Some t, true -> (
+        match t.open_instances with
+        | 0 ->
+            Cache.remove cache (root, readonly);
+            new_instance ()
+        | _ ->
+            Log.debug (fun l ->
+                l "[%s] found in cache" (Filename.basename root));
+            t.open_instances <- t.open_instances + 1;
+            if readonly then sync_log t;
+            let t = ref (Some t) in
+            if fresh then clear t;
+            t)
 
   let interpolation_search index key =
     let hashed_key = K.hash key in

--- a/src/index.ml
+++ b/src/index.ml
@@ -387,7 +387,7 @@ struct
 
   let empty_cache = Cache.create
 
-  let v ?(auto_flush_callback = Fun.id) ?(cache = empty_cache ())
+  let v ?(auto_flush_callback = fun () -> ()) ?(cache = empty_cache ())
       ?(fresh = false) ?(readonly = false) ~log_size root =
     let new_instance () =
       let instance =

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -134,7 +134,7 @@ module type S = sig
   (** The constructor for indexes.
 
       @param auto_flush_callback adds a callback before an auto flush.
-      @param cache a cache instance to use for instance sharing.
+      @param cache used for instance sharing.
       @param fresh whether an existing index should be overwritten.
       @param read_only whether read-only mode is enabled for this index.
       @param log_size the maximum number of bindings in the `log` IO. *)

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -117,8 +117,15 @@ module type S = sig
   type value
   (** The type for values. *)
 
+  type cache
+  (** The type for caches of index instances. *)
+
+  val empty_cache : unit -> cache
+  (** Construct a new empty cache of index instances. *)
+
   val v :
     ?auto_flush_callback:(unit -> unit) ->
+    ?cache:cache ->
     ?fresh:bool ->
     ?readonly:bool ->
     log_size:int ->
@@ -127,6 +134,7 @@ module type S = sig
   (** The constructor for indexes.
 
       @param auto_flush_callback adds a callback before an auto flush.
+      @param cache a cache instance to use for instance sharing.
       @param fresh whether an existing index should be overwritten.
       @param read_only whether read-only mode is enabled for this index.
       @param log_size the maximum number of bindings in the `log` IO. *)
@@ -180,7 +188,7 @@ module type S = sig
 end
 
 module type Index = sig
-  (** The input of [Make] for keys. *)
+  (** The input of {!Make} for keys. *)
   module type Key = sig
     (* N.B. We use [sig ... end] redirections to avoid linking to the [_intf]
        file in the generated docs. Once Odoc 2 is released, this can be
@@ -190,12 +198,8 @@ module type Index = sig
     (** @inline *)
   end
 
-  module Stats : sig
-    include module type of Stats
-    (** @inline *)
-  end
-
-  (** The input of [Make] for values. The same requirements as for [Key] apply. *)
+  (** The input of {!Make} for values. The same requirements as for {!Key}
+      apply. *)
   module type Value = sig
     include Value
     (** @inline *)
@@ -213,6 +217,13 @@ module type Index = sig
 
   module type THREAD = sig
     include THREAD
+    (** @inline *)
+  end
+
+  (** Signatures and implementations of caches. {!Make} requires a cache in
+      order to provide instance sharing. *)
+  module Cache : sig
+    include module type of Cache
     (** @inline *)
   end
 
@@ -234,8 +245,19 @@ module type Index = sig
   (** The exception raised when any operation is attempted on a closed index,
       except for [close], which is idempotent. *)
 
-  module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :
-    S with type key = K.t and type value = V.t
+  module Make
+      (K : Key)
+      (V : Value)
+      (IO : IO)
+      (M : MUTEX)
+      (T : THREAD)
+      (C : Cache.S) : S with type key = K.t and type value = V.t
+
+  (** Run-time metric tracking for index instances. *)
+  module Stats : sig
+    include module type of Stats
+    (** @inline *)
+  end
 
   (** These modules should not be used. They are exposed purely for testing
       purposes. *)
@@ -291,7 +313,12 @@ module type Index = sig
           offset. *)
     end
 
-    module Make (K : Key) (V : Value) (IO : IO) (M : MUTEX) (T : THREAD) :
-      S with type key = K.t and type value = V.t
+    module Make
+        (K : Key)
+        (V : Value)
+        (IO : IO)
+        (M : MUTEX)
+        (T : THREAD)
+        (C : Cache.S) : S with type key = K.t and type value = V.t
   end
 end

--- a/test/cache.ml
+++ b/test/cache.ml
@@ -1,0 +1,31 @@
+let check_none msg = Alcotest.(check (option reject)) msg None
+
+let check_some msg x = Alcotest.(check (option int)) msg (Some x)
+
+let test_noop () =
+  let open Index.Cache.Noop in
+  (* Test that added entries are never found. *)
+  let c = create () in
+  find c "not-added" |> check_none "Cannot find non-existent value";
+  add c "added" 1;
+  find c "added" |> check_none "Cannot find added value";
+  remove c "added";
+  find c "added" |> check_none "Can't find added value after remove";
+  ()
+
+let test_unbounded () =
+  let open Index.Cache.Unbounded in
+  (* Test that added entries are always found. *)
+  let c = create () in
+  find c "not-added" |> check_none "Cannot find non-existent value";
+  add c "added" 1;
+  find c "added" |> check_some "Can find added value" 1;
+  remove c "added";
+  find c "added" |> check_none "Can't find added value after remove";
+  ()
+
+let tests =
+  [
+    Alcotest.test_case "noop" `Quick test_noop;
+    Alcotest.test_case "unbounded" `Quick test_unbounded;
+  ]

--- a/test/cache.ml
+++ b/test/cache.ml
@@ -10,7 +10,7 @@ let test_noop () =
   add c "added" 1;
   find c "added" |> check_none "Cannot find added value";
   remove c "added";
-  find c "added" |> check_none "Can't find added value after remove";
+  find c "added" |> check_none "Cannot find added value after remove";
   ()
 
 let test_unbounded () =
@@ -21,7 +21,7 @@ let test_unbounded () =
   add c "added" 1;
   find c "added" |> check_some "Can find added value" 1;
   remove c "added";
-  find c "added" |> check_none "Can't find added value after remove";
+  find c "added" |> check_none "Cannot find added value after remove";
   ()
 
 let tests =

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
- (name search)
+ (name main)
  (package index)
  (libraries index alcotest))

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,0 +1,2 @@
+let () =
+  Alcotest.run "index" [ ("cache", Cache.tests); ("search", Search.tests) ]

--- a/test/search.ml
+++ b/test/search.ml
@@ -98,14 +98,10 @@ let interpolation_constant_metric () =
       |> Alcotest.(check string) "" v)
     array
 
-let () =
-  Random.self_init ();
-  Alcotest.run "search"
-    [
-      ( "interpolation",
-        [
-          Alcotest.test_case "unique" `Quick interpolation_unique;
-          Alcotest.test_case "constant metric" `Quick
-            interpolation_constant_metric;
-        ] );
-    ]
+let tests =
+  [
+    Alcotest.test_case "unique" `Quick interpolation_unique;
+    Alcotest.test_case "constant metric" `Quick interpolation_constant_metric;
+  ]
+
+let () = Random.self_init ()

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -82,7 +82,6 @@ struct
   type t = {
     rw : Index.t;
     tbl : (string, string) Hashtbl.t;
-    cache : Index.cache;
     clone : ?fresh:bool -> readonly:bool -> unit -> Index.t;
   }
 
@@ -94,7 +93,7 @@ struct
     let clone ?(fresh = false) ~readonly () =
       Index.v ~cache ~fresh ~log_size:4 ~readonly name
     in
-    { rw; tbl; clone; cache }
+    { rw; tbl; clone }
 
   let full_index ?(size = 103) () =
     let name = fresh_name "full_index" in
@@ -111,7 +110,7 @@ struct
     let clone ?(fresh = false) ~readonly () =
       Index.v ~cache ~fresh ~log_size:4 ~readonly name
     in
-    { rw = t; tbl; clone; cache }
+    { rw = t; tbl; clone }
 end
 
 let ignore_value (_ : Value.t) = ()

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -17,6 +17,10 @@ let reporter ?(prefix = "") () =
   in
   { Logs.report }
 
+let src = Logs.Src.create "test/unix" ~doc:"Index_unix tests"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
 let report () =
   Logs_threaded.enable ();
   Logs.set_level (Some Logs.Debug);
@@ -118,6 +122,9 @@ let ignore_value (_ : Value.t) = ()
 let ignore_bool (_ : bool) = ()
 
 let ignore_index (_ : Index.t) = ()
+
+let pp_binding ppf (key, value) =
+  Fmt.pf ppf "{ %a → %a }" Key.pp key Value.pp value
 
 let check_completed = function
   | Ok `Completed -> ()

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -3,6 +3,8 @@ val random_char : unit -> char
 val report : unit -> unit
 (** Set logs reporter at [Logs.Debug] level *)
 
+module Log : Logs.LOG
+
 (** Simple key/value modules with String type and a random constructor *)
 module Key : sig
   include Index.Key with type t = string
@@ -44,6 +46,8 @@ val ignore_value : Value.t -> unit
 val ignore_bool : bool -> unit
 
 val ignore_index : Index.t -> unit
+
+val pp_binding : (Key.t * Value.t) Fmt.t
 
 val check_completed :
   ([ `Aborted | `Completed ], [ `Async_exn of exn ]) result -> unit

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -22,9 +22,10 @@ module Index : Index.Private.S with type key = Key.t and type value = Value.t
 module Make_context (Config : sig
   val root : string
 end) : sig
-  type t = {
+  type t = private {
     rw : Index.t;
     tbl : (string, string) Hashtbl.t;
+    cache : Index.cache;
     clone : ?fresh:bool -> readonly:bool -> unit -> Index.t;
   }
 

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -25,7 +25,6 @@ end) : sig
   type t = private {
     rw : Index.t;
     tbl : (string, string) Hashtbl.t;
-    cache : Index.cache;
     clone : ?fresh:bool -> readonly:bool -> unit -> Index.t;
   }
 

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -252,9 +252,9 @@ module Readonly = struct
     in
     let Context.{ rw; tbl; clone } = Context.full_index () in
     let ro = clone ~readonly:true () in
-    check_equivalence ro tbl;
     Index.clear rw;
     Index.sync ro;
+    Log.info (fun m -> m "Checking that RO observes the empty index");
     Hashtbl.iter (fun k _ -> check_no_index_entry ro k) tbl;
     Index.close rw;
     Index.close ro;
@@ -302,11 +302,12 @@ module Readonly = struct
 
   let readonly_v_in_sync () =
     let Context.{ rw; clone; _ } = Context.full_index () in
-    let k = Key.v () in
-    let v = Value.v () in
+    let k, v = (Key.v (), Value.v ()) in
     Index.replace rw k v;
     Index.flush rw;
     let ro = clone ~readonly:true () in
+    Log.info (fun m ->
+        m "Checking that RO observes the flushed binding %a" pp_binding (k, v));
     check_index_entry ro k v;
     Index.close rw;
     Index.close ro

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -159,14 +159,14 @@ end
 (* Tests of behaviour after restarting the index *)
 module DuplicateInstance = struct
   let find_present () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     check_equivalence rw tbl;
     Index.close rw;
     Index.close rw2
 
   let find_absent () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     test_find_absent rw tbl;
     Index.close rw;
@@ -180,7 +180,7 @@ module DuplicateInstance = struct
     Index.close rw2
 
   let membership () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ tbl; clone; rw } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     check_equivalence_mem rw2 tbl;
     Index.close rw;
@@ -250,7 +250,7 @@ module Readonly = struct
       Alcotest.check_raises (Fmt.strf "Find %s key after clearing." k) Not_found
         (fun () -> ignore_value (Index.find index k))
     in
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let ro = clone ~readonly:true () in
     check_equivalence ro tbl;
     Index.clear rw;
@@ -434,14 +434,14 @@ end
 (* Tests of {Index.close} *)
 module Close = struct
   let close_reopen_rw () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     Index.close rw;
     let w = clone ~readonly:false () in
     check_equivalence w tbl;
     Index.close w
 
   let find_absent () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     Index.close rw;
     let rw = clone ~readonly:false () in
     test_find_absent rw tbl;
@@ -455,14 +455,14 @@ module Close = struct
     Index.close rw
 
   let open_readonly_close_rw () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let ro = clone ~readonly:true () in
     Index.close rw;
     check_equivalence ro tbl;
     Index.close ro
 
   let close_reopen_readonly () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     Index.close rw;
     let ro = clone ~readonly:true () in
     check_equivalence ro tbl;
@@ -608,7 +608,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created before. *)
   let clone_then_filter () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     let rw2 = clone ~readonly:false () in
@@ -621,7 +621,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created after. *)
   let filter_then_clone () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));
@@ -634,7 +634,7 @@ module Filter = struct
   (** Test that using [filter] doesn't affect fresh clones created later at the
       same path. *)
   let empty_after_filter_and_fresh () =
-    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
+    let Context.{ rw; tbl; clone } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -159,14 +159,14 @@ end
 (* Tests of behaviour after restarting the index *)
 module DuplicateInstance = struct
   let find_present () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     check_equivalence rw tbl;
     Index.close rw;
     Index.close rw2
 
   let find_absent () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     test_find_absent rw tbl;
     Index.close rw;
@@ -180,7 +180,7 @@ module DuplicateInstance = struct
     Index.close rw2
 
   let membership () =
-    let Context.{ tbl; clone; rw } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let rw2 = clone ~readonly:false () in
     check_equivalence_mem rw2 tbl;
     Index.close rw;
@@ -188,10 +188,14 @@ module DuplicateInstance = struct
 
   let fail_restart_fresh () =
     let reuse_name = Context.fresh_name "empty_index" in
-    let rw = Index.v ~fresh:true ~readonly:false ~log_size:4 reuse_name in
+    let cache = Index.empty_cache () in
+    let rw =
+      Index.v ~cache ~fresh:true ~readonly:false ~log_size:4 reuse_name
+    in
     let exn = I.RO_not_allowed in
     Alcotest.check_raises "Index readonly cannot be fresh." exn (fun () ->
-        ignore_index (Index.v ~fresh:true ~readonly:true ~log_size:4 reuse_name));
+        ignore_index
+          (Index.v ~cache ~fresh:true ~readonly:true ~log_size:4 reuse_name));
     Index.close rw
 
   let sync () =
@@ -246,7 +250,7 @@ module Readonly = struct
       Alcotest.check_raises (Fmt.strf "Find %s key after clearing." k) Not_found
         (fun () -> ignore_value (Index.find index k))
     in
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let ro = clone ~readonly:true () in
     check_equivalence ro tbl;
     Index.clear rw;
@@ -430,7 +434,7 @@ end
 (* Tests of {Index.close} *)
 module Close = struct
   let close_reopen_rw () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     Index.close rw;
     let w = clone ~readonly:false () in
     check_equivalence w tbl;
@@ -451,14 +455,14 @@ module Close = struct
     Index.close rw
 
   let open_readonly_close_rw () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let ro = clone ~readonly:true () in
     Index.close rw;
     check_equivalence ro tbl;
     Index.close ro
 
   let close_reopen_readonly () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     Index.close rw;
     let ro = clone ~readonly:true () in
     check_equivalence ro tbl;
@@ -604,7 +608,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created before. *)
   let clone_then_filter () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     let rw2 = clone ~readonly:false () in
@@ -617,7 +621,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created after. *)
   let filter_then_clone () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));
@@ -630,7 +634,7 @@ module Filter = struct
   (** Test that using [filter] doesn't affect fresh clones created later at the
       same path. *)
   let empty_after_filter_and_fresh () =
-    let Context.{ rw; tbl; clone } = Context.full_index () in
+    let Context.{ rw; tbl; clone; _ } = Context.full_index () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));


### PR DESCRIPTION
Add a new `Cache.S` signature with two implementations: `Noop` and `Unbounded`. A cache implementation must now be provided to `Index.Make`.

The explicit instance sharing is Implemented with an _optional_ `?cache` argument to `Index.v`, from which the instance may be picked (and to which any new instances will be added). `cache` is perhaps not the best name for this argument: I picked it just because that's the necessary semantics for the underlying datastructure. (`pool`? `sharing_pool`? Ideas welcome.)