### PR TITLE
auto flush callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,25 @@
+# Unreleased
+
+## Added
+
+- Added `auto_flush_callback` parameter to the creation of a store, to register
+  a callback before a flush. (#189)
+
+## Changed
+
+- `Index.close` will now abort an ongoing asynchronous merge operation, rather
+  than waiting for it to finish. (#185)
+
+## Fixed
+
+- Added values after a clear are found by read-only instances. (#168)
+
 # 1.2.1 (2020-06-24)
 
 ## Added
 
 - Added `Index_unix.Syscalls`, a module exposing various Unix bindings for
   interacting with file-systems. (#176)
-
-## Changed
-
-- `Index.close` will now abort an ongoing asynchronous merge operation, rather
-  than waiting for it to finish. (#185)
 
 ## Fixed
 

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -114,9 +114,16 @@ module type S = sig
   type value
   (** The type for values. *)
 
-  val v : ?fresh:bool -> ?readonly:bool -> log_size:int -> string -> t
+  val v :
+    ?auto_flush_callback:(unit -> unit) ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    log_size:int ->
+    string ->
+    t
   (** The constructor for indexes.
 
+      @param auto_flush_callback adds a callback before an auto flush.
       @param fresh whether an existing index should be overwritten.
       @param read_only whether read-only mode is enabled for this index.
       @param log_size the maximum number of bindings in the `log` IO. *)

--- a/src/io.mli
+++ b/src/io.mli
@@ -19,6 +19,7 @@ module type S = sig
   type t
 
   val v :
+    ?auto_flush_callback:(unit -> unit) ->
     readonly:bool ->
     fresh:bool ->
     generation:int64 ->


### PR DESCRIPTION
This PR adds a hook at the end of the merge, to give a change to `irmin-pack` to flush files to disk before the index does. This prevents invalid reads for RO in `irmin-pack`, where a key is found in index but not in pack.

On top of https://github.com/mirage/index/pull/175.