### PR TITLE
Add an is_merging function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   a callback before a flush. (#189)
 - Added `Stats.merge_durations` to list the duration of the last 10 merges.
   (#193)
+- Added `is_merging` to detect if a merge is running. (#192)
 
 ## Changed
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -653,6 +653,11 @@ struct
         Thread.return `Completed
     | Some witness -> merge ?hook ~witness t
 
+  let is_merging t =
+    let t = check_open t in
+    if t.config.readonly then raise RO_not_allowed;
+    Mutex.is_locked t.merge_lock
+
   let replace t key value =
     let t = check_open t in
     Stats.incr_nb_replace ();

--- a/src/index.ml
+++ b/src/index.ml
@@ -653,6 +653,9 @@ struct
         Thread.return `Completed
     | Some witness -> merge ?hook ~witness t
 
+  (** [t.merge_lock] is used to detect an ongoing merge. Other operations can
+      take this lock, but as they are not async, we consider this to be a good
+      enough approximations. *)
   let is_merging t =
     let t = check_open t in
     if t.config.readonly then raise RO_not_allowed;

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -83,8 +83,7 @@ module type MUTEX = sig
       unlocks [t]. *)
 
   val is_locked : t -> bool
-  (** Return true is the mutex is locked, but does not block the mutex
-      otherwise.*)
+  (** [is_locked t] returns [true] if the mutex is locked, without locking [t]. *)
 end
 
 module type THREAD = sig
@@ -176,7 +175,7 @@ module type S = sig
       {!RW_not_allowed} if called by a read-write index. *)
 
   val is_merging : t -> bool
-  (** [is_merging t] returns true if [t] is running an async merge. Raises
+  (** [is_merging t] returns true if [t] is running a merge. Raises
       {!RO_not_allowed} if called by a read-only index. *)
 end
 

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -81,6 +81,10 @@ module type MUTEX = sig
   val with_lock : t -> (unit -> 'a) -> 'a
   (** [with_lock t f] first obtains [t], then computes [f ()], and finally
       unlocks [t]. *)
+
+  val is_locked : t -> bool
+  (** Return true is the mutex is locked, but does not block the mutex
+      otherwise.*)
 end
 
 module type THREAD = sig
@@ -170,6 +174,10 @@ module type S = sig
   val sync : t -> unit
   (** [sync t] syncs a read-only index with the files on disk. Raises
       {!RW_not_allowed} if called by a read-write index. *)
+
+  val is_merging : t -> bool
+  (** [is_merging t] returns true if [t] is running an async merge. Raises
+      {!RO_not_allowed} if called by a read-only index. *)
 end
 
 module type Index = sig

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -278,6 +278,11 @@ module Mutex = struct
     with e ->
       Mutex.unlock t;
       raise e
+
+  let is_locked t =
+    let locked = Mutex.try_lock t in
+    if locked then Mutex.unlock t;
+    not locked
 end
 
 module Thread = struct


### PR DESCRIPTION
`is_merging` returns true is the index is running an async merge. 

I used the `merge_lock` to detect that a merge is ongoing. Other operations take this lock (`clear` and `close`), but as they are not async, so it should be fine. 

