### PR TITLE
Add timer for merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Added `auto_flush_callback` parameter to the creation of a store, to register
   a callback before a flush. (#189)
+- Added `Stats.merge_durations` to list the duration of the last 10 merges.
+  (#193)
 
 ## Changed
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -93,6 +93,8 @@ module Benchmark = struct
     write_amplification_calls : float;
     write_amplification_size : float;
     replace_times : float list;
+    merge_times : float list;
+    nb_merges : int;
   }
   [@@deriving yojson]
 
@@ -113,6 +115,8 @@ module Benchmark = struct
     let ops_per_sec = nb_entriesf /. time in
     let mbs_per_sec = entry_sizef *. nb_entriesf /. 1_048_576. /. time in
     let replace_times = stats.replace_times in
+    let merge_times = stats.merge_times in
+    let nb_merges = stats.nb_merge in
     {
       time;
       ops_per_sec;
@@ -122,7 +126,12 @@ module Benchmark = struct
       write_amplification_calls;
       write_amplification_size;
       replace_times;
+      merge_times;
+      nb_merges;
     }
+
+  let pp_list times =
+    String.concat "" (List.map (fun f -> string_of_float f ^ "; ") times)
 
   let pp_result fmt result =
     Format.fprintf fmt
@@ -132,10 +141,13 @@ module Benchmark = struct
        Read amplification in syscalls: %f@\n\
        Read amplification in bytes: %f@\n\
        Write amplification in syscalls: %f@\n\
-       Write amplification in bytes: %f" result.time result.ops_per_sec
-      result.mbs_per_sec result.read_amplification_calls
-      result.read_amplification_size result.write_amplification_calls
-      result.write_amplification_size
+       Write amplification in bytes: %f@\n\
+       Last 10 merges: %s@\n\
+       Number of merges : %d" result.time result.ops_per_sec result.mbs_per_sec
+      result.read_amplification_calls result.read_amplification_size
+      result.write_amplification_calls result.write_amplification_size
+      (pp_list result.merge_times)
+      result.nb_merges
 end
 
 let make_bindings_pool nb_entries =

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -19,7 +19,7 @@ let src =
         int "bytes_written" t.bytes_written;
         int "merge" t.nb_merge;
         int "replace" t.nb_replace;
-        head "replace_time" t.replace_times;
+        head "replace_durations" t.replace_durations;
       ]
   in
   Src.v "bench" ~tags ~data
@@ -92,8 +92,8 @@ module Benchmark = struct
     read_amplification_size : float;
     write_amplification_calls : float;
     write_amplification_size : float;
-    replace_times : float list;
-    merge_times : float list;
+    replace_durations : float list;
+    merge_durations : float list; [@key "merge_durations_us"]
     nb_merges : int;
   }
   [@@deriving yojson]
@@ -114,8 +114,8 @@ module Benchmark = struct
     in
     let ops_per_sec = nb_entriesf /. time in
     let mbs_per_sec = entry_sizef *. nb_entriesf /. 1_048_576. /. time in
-    let replace_times = stats.replace_times in
-    let merge_times = stats.merge_times in
+    let replace_durations = stats.replace_durations in
+    let merge_durations = stats.merge_durations in
     let nb_merges = stats.nb_merge in
     {
       time;
@@ -125,13 +125,12 @@ module Benchmark = struct
       read_amplification_size;
       write_amplification_calls;
       write_amplification_size;
-      replace_times;
-      merge_times;
+      replace_durations;
+      merge_durations;
       nb_merges;
     }
 
-  let pp_list times =
-    String.concat "" (List.map (fun f -> string_of_float f ^ "; ") times)
+  let pp_list times = String.concat "; " (List.map string_of_float times)
 
   let pp_result fmt result =
     Format.fprintf fmt
@@ -142,11 +141,11 @@ module Benchmark = struct
        Read amplification in bytes: %f@\n\
        Write amplification in syscalls: %f@\n\
        Write amplification in bytes: %f@\n\
-       Last 10 merges: %s@\n\
+       Last 10 merge durations (μs): %s@\n\
        Number of merges : %d" result.time result.ops_per_sec result.mbs_per_sec
       result.read_amplification_calls result.read_amplification_size
       result.write_amplification_calls result.write_amplification_size
-      (pp_list result.merge_times)
+      (pp_list result.merge_durations)
       result.nb_merges
 end
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -618,7 +618,9 @@ struct
           Mutex.unlock t.merge_lock;
           `Aborted
     in
-    if blocking then go () |> Thread.return else Thread.async go
+    let go_with_timer () = Stats.merge_with_timer go in
+    if blocking then go_with_timer () |> Thread.return
+    else Thread.async go_with_timer
 
   let get_witness t =
     match t.log with

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -4,9 +4,9 @@ type t = {
   mutable bytes_written : int;
   mutable nb_writes : int;
   mutable nb_merge : int;
-  mutable merge_times : float list;
+  mutable merge_durations : float list;
   mutable nb_replace : int;
-  mutable replace_times : float list;
+  mutable replace_durations : float list;
   mutable nb_sync : int;
   mutable time_sync : float;
 }
@@ -17,10 +17,11 @@ type t = {
     - [bytes_written] is the number of bytes written to disk;
     - [nb_writes] is the number of writes to disk;
     - [nb_merge] is the number of times a merge occurred;
-    - [merge_times] lists how much time the last 10 merge operations took.
+    - [merge_durations] lists how much time the last 10 merge operations took
+      (in microseconds);
     - [nb_replace] is the number of calls to [I.replace];
-    - [replace_times] lists how much time replace operations took. Each element
-      is an average of [n] consecutive replaces, where [n] is the
+    - [replace_durations] lists how much time replace operations took. Each
+      element is an average of [n] consecutive replaces, where [n] is the
       [sampling_interval] specified when calling [end_replace].
     - [time_sync] is the duration of the latest call to sync. *)
 

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -4,6 +4,7 @@ type t = {
   mutable bytes_written : int;
   mutable nb_writes : int;
   mutable nb_merge : int;
+  mutable merge_times : float list;
   mutable nb_replace : int;
   mutable replace_times : float list;
   mutable nb_sync : int;
@@ -16,6 +17,7 @@ type t = {
     - [bytes_written] is the number of bytes written to disk;
     - [nb_writes] is the number of writes to disk;
     - [nb_merge] is the number of times a merge occurred;
+    - [merge_times] lists how much time the last 10 merge operations took.
     - [nb_replace] is the number of calls to [I.replace];
     - [replace_times] lists how much time replace operations took. Each element
       is an average of [n] consecutive replaces, where [n] is the
@@ -41,3 +43,5 @@ val start_replace : unit -> unit
 val end_replace : sampling_interval:int -> unit
 
 val sync_with_timer : (unit -> unit) -> unit
+
+val merge_with_timer : (unit -> 'a) -> 'a


### PR DESCRIPTION
As merge is an async operation, I think we have to store a list of the last `n` merges. I picked the last 10 merges, but we can instead have `n` as parameter, if we think its better. 

Every merge operation is timed by default. 
  
