### PR TITLE
New Index.clear semantics

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -128,8 +128,8 @@ struct
     Log.debug (fun l ->
         l "[%s] flushing instance" (Filename.basename instance.root));
     if instance.config.readonly then raise RO_not_allowed;
-    may (fun log -> IO.sync ~with_fsync log.io) instance.log;
-    may (fun log -> IO.sync ~with_fsync log.io) instance.log_async
+    may (fun log -> IO.flush ~with_fsync log.io) instance.log;
+    may (fun log -> IO.flush ~with_fsync log.io) instance.log_async
 
   let flush ?(with_fsync = false) t =
     let t = check_open t in
@@ -372,7 +372,7 @@ struct
                 Tbl.replace log.mem e.key e.value;
                 append_key_value log.io e.key e.value)
               io;
-            IO.sync log.io;
+            IO.flush log.io;
             IO.clear ~generation io)
           log;
       IO.close io );
@@ -602,7 +602,7 @@ struct
                   Tbl.replace log.mem key value;
                   append_key_value log.io key value)
                 log_async.mem;
-              IO.sync log.io;
+              IO.flush log.io;
               t.log_async <- None);
           hook `After;
           IO.clear ~generation log_async.io;
@@ -760,7 +760,7 @@ struct
     let f t =
       Stats.incr_nb_sync ();
       let t = check_open t in
-      Log.info (fun l -> l "[%s] ro_sync" (Filename.basename t.root));
+      Log.info (fun l -> l "[%s] sync" (Filename.basename t.root));
       if t.config.readonly then sync_log ?hook t else raise RW_not_allowed
     in
     Stats.sync_with_timer (fun () -> f t)

--- a/src/io.mli
+++ b/src/io.mli
@@ -57,6 +57,8 @@ module type S = sig
 
   val close : t -> unit
 
+  val unlink : t -> unit
+
   type lock
 
   val lock : string -> lock

--- a/src/io.mli
+++ b/src/io.mli
@@ -39,7 +39,7 @@ module type S = sig
 
   val clear : generation:int64 -> t -> unit
 
-  val sync : ?with_fsync:bool -> t -> unit
+  val flush : ?with_fsync:bool -> t -> unit
 
   val version : t -> string
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -161,7 +161,8 @@ module IO : Index.IO = struct
     t.flushed <- t.header;
     Header.set_header t { offset = t.offset; generation };
     Raw.Fan.set t.raw "";
-    Buffer.clear t.buf
+    Buffer.clear t.buf;
+    flush ~with_fsync:true t
 
   let unlink t =
     Log.debug (fun l -> l "Unlinking %s" t.file);

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -70,6 +70,7 @@ module IO : Index.IO = struct
     dst.raw <- src.raw
 
   let close t =
+    Log.debug (fun l -> l "Closing %s" t.file);
     if not t.readonly then Buffer.clear t.buf;
     Raw.close t.raw
 
@@ -160,6 +161,10 @@ module IO : Index.IO = struct
     Header.set_header t { offset = t.offset; generation };
     Raw.Fan.set t.raw "";
     Buffer.clear t.buf
+
+  let unlink t =
+    Log.debug (fun l -> l "Unlinking %s" t.file);
+    try Unix.unlink t.file with Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 
   let buffers = Hashtbl.create 256
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -42,7 +42,7 @@ module IO : Index.IO = struct
     auto_flush_callback : unit -> unit;
   }
 
-  let sync ?(with_fsync = false) t =
+  let flush ?(with_fsync = false) t =
     if t.readonly then raise RO_not_allowed;
     t.auto_flush_callback ();
     let buf = Buffer.contents t.buf in
@@ -50,6 +50,7 @@ module IO : Index.IO = struct
     Buffer.clear t.buf;
     if buf = "" then ()
     else (
+      Log.debug (fun l -> l "[%s] flushing %d bytes" t.file (String.length buf));
       Raw.unsafe_write t.raw ~off:t.flushed buf;
       Raw.Offset.set t.raw offset;
       assert (t.flushed ++ Int64.of_int (String.length buf) = t.header ++ offset);
@@ -59,7 +60,7 @@ module IO : Index.IO = struct
   let name t = t.file
 
   let rename ~src ~dst =
-    sync ~with_fsync:true src;
+    flush ~with_fsync:true src;
     Raw.close dst.raw;
     Unix.rename src.file dst.file;
     Buffer.clear dst.buf;
@@ -81,7 +82,7 @@ module IO : Index.IO = struct
     Buffer.add_string t.buf buf;
     let len = Int64.of_int (String.length buf) in
     t.offset <- t.offset ++ len;
-    if t.offset -- t.flushed > auto_flush_limit then sync t
+    if t.offset -- t.flushed > auto_flush_limit then flush t
 
   let read t ~off ~len buf =
     if not t.readonly then assert (t.header ++ off <= t.flushed);

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -44,7 +44,7 @@ let populate_random ~size io =
   in
   let mem_arr = Array.of_list (List.rev (loop [] size)) in
   let io_arr = IOArray.v io in
-  IO.sync io;
+  IO.flush io;
   (mem_arr, io_arr)
 
 (* Tests *)


### PR DESCRIPTION
- `clear` now removes the index file(s)
- concurrent read-only instances see the changes only after a `sync`.
- When a read-only instance sync on a cleared file, it detects the change
  of generation and close/re-opam the file(s) on disk.