### PR TITLE
Scope test resource lifetimes inside continuations

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -28,6 +28,7 @@ depends: [
   "crowbar" {with-test}
   "re" {with-test}
   "stdlib-shims"
+  "ocaml-syntax-shims" {with-test}
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -28,18 +28,25 @@ end) : sig
     rw : Index.t;
     tbl : (string, string) Hashtbl.t;
     clone : ?fresh:bool -> readonly:bool -> unit -> Index.t;
+    close_all : unit -> unit;
   }
 
   val fresh_name : string -> string
   (** [fresh_name typ] is a clean directory for a resource of type [typ]. *)
 
-  val empty_index : unit -> t
-  (** Fresh, empty index. *)
+  val with_empty_index : unit -> (t -> 'a) -> 'a
+  (** [with_empty_index f] applies [f] to a fresh empty index. Afterwards, the
+      index and any clones are closed. *)
 
-  val full_index : ?size:int -> unit -> t
-  (** Fresh index with a random table of key/value pairs, and a given
-      constructor for opening clones of the index at the same location. *)
+  val with_full_index : ?size:int -> unit -> (t -> 'a) -> 'a
+  (** [with_full_index f] applies [f] to a fresh index with a random table of
+      key/value pairs. [f] also gets a constructor for opening clones of the
+      index at the same location. Afterwards, the index and any clones are
+      closed. *)
 end
+
+val ( let* ) : ('a -> 'b) -> 'a -> 'b
+(** CPS monad *)
 
 val ignore_value : Value.t -> unit
 

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -2,4 +2,5 @@
  (names main force_merge io_array)
  (package index)
  (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims
-   threads.posix))
+   threads.posix)
+ (preprocess future_syntax))


### PR DESCRIPTION
Change `Context.<>` functions to take a continuation representing the test.  After the test is complete, the main index instance and any clones created during the test will be closed. This avoids needing to explicitly `close` various indices for most tests.

This catches quite a few cases where test indices weren't being closed properly.