### PR TITLE
IO refactoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,10 +16,17 @@
   than waiting for it to finish. (#185)
 - `sync` has to be called by the read-only instance to synchronise with the
   files on disk. (#175)
-
 - Caching of `Index` instances is now explicit: `Index.Make` requires a cache
   implementation, and `Index.v` may be passed a cache to be used for instance
   sharing. The default behaviour is _not_ to share instances. (#188)
+- `IO.{offset,generation}` refactoring (#207, @samoht)
+  - Remove IO.{set_generation,IO.get_generation,force_offset}
+  - Change `IO.offset` to take a `~force` argument:
+    - `IO.force_offset` becomes `IO.offset ~force:true`
+    - `IO.offset` becomes `IO.offset ~force:false`
+  - Add `IO.generation`
+    - `IO.get_generation` becomes `IO.generation ~force:true`
+    - `IO.generation ~force:false` is the cached generation number
 
 ## Fixed
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -153,7 +153,9 @@ struct
   let page_size = Int64.mul entry_sizeL 1_000L
 
   let iter_io_off ?min:(min_off = 0L) ?max:max_off f io =
-    let max_off = match max_off with None -> IO.offset io | Some m -> m in
+    let max_off =
+      match max_off with None -> IO.offset ~force:false io | Some m -> m
+    in
     let rec aux offset =
       let remaining = Int64.sub max_off offset in
       if remaining <= 0L then ()
@@ -242,8 +244,8 @@ struct
     match t.log_async with
     | None -> t.log_async <- try_load_log t (log_async_path t.root)
     | Some log ->
-        let offset = IO.offset log.io in
-        let new_offset = IO.force_offset log.io in
+        let offset = IO.offset ~force:false log.io in
+        let new_offset = IO.offset ~force:true log.io in
         if generation_change || offset <> new_offset then sync_log_entries log
 
   let sync_index ~generation t =
@@ -255,7 +257,7 @@ struct
         IO.v ~fresh:false ~readonly:true ~generation ~fan_size:0L index_path
       in
       let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-      if IO.offset io = 0L then t.index <- None
+      if IO.offset ~force:false io = 0L then t.index <- None
       else t.index <- Some { fan_out; io }
 
   let sync_log ?(hook = fun _ -> ()) t =
@@ -267,7 +269,7 @@ struct
     match t.log with
     | None -> sync_log_async t
     | Some log ->
-        let log_offset = IO.offset log.io in
+        let log_offset = IO.offset ~force:false log.io in
         hook `Before_offset_read;
         let h = IO.Header.get log.io in
         sync_log_async ~generation_change:(t.generation <> h.generation) t;
@@ -303,7 +305,7 @@ struct
           IO.v ?auto_flush_callback ~fresh ~readonly ~generation:0L ~fan_size:0L
             log_path
         in
-        let entries = Int64.div (IO.offset io) entry_sizeL in
+        let entries = Int64.div (IO.offset ~force:false io) entry_sizeL in
         Log.debug (fun l ->
             l "[%s] log file detected. Loading %Ld entries"
               (Filename.basename root) entries);
@@ -312,7 +314,9 @@ struct
         Some { io; mem }
     in
     let generation =
-      match log with None -> 0L | Some log -> IO.get_generation log.io
+      match log with
+      | None -> 0L
+      | Some log -> IO.generation ~force:false log.io
     in
     let log_async_path = log_async_path root in
     (* If we are in readonly mode, the log_async will be read during sync_log so
@@ -322,7 +326,7 @@ struct
         IO.v ?auto_flush_callback ~fresh ~readonly:false ~generation:0L
           ~fan_size:0L log_async_path
       in
-      let entries = Int64.div (IO.offset io) entry_sizeL in
+      let entries = Int64.div (IO.offset ~force:false io) entry_sizeL in
       Log.debug (fun l ->
           l "[%s] log_async file detected. Loading %Ld entries"
             (Filename.basename root) entries);
@@ -347,7 +351,7 @@ struct
           IO.v ?auto_flush_callback ~fresh ~readonly ~generation ~fan_size:0L
             index_path
         in
-        let entries = Int64.div (IO.offset io) entry_sizeL in
+        let entries = Int64.div (IO.offset ~force:false io) entry_sizeL in
         if entries = 0L then None
         else (
           Log.debug (fun l ->
@@ -459,11 +463,11 @@ struct
     match find_instance t key with _ -> true | exception Not_found -> false
 
   let append_buf_fanout fan_out hash buf_str dst_io =
-    Fan.update fan_out hash (IO.offset dst_io);
+    Fan.update fan_out hash (IO.offset ~force:false dst_io);
     IO.append dst_io buf_str
 
   let append_entry_fanout fan_out entry dst_io =
-    Fan.update fan_out entry.key_hash (IO.offset dst_io);
+    Fan.update fan_out entry.key_hash (IO.offset ~force:false dst_io);
     append_key_value dst_io entry.key entry.value
 
   let rec merge_from_log fan_out log log_i hash_e dst_io =
@@ -487,7 +491,7 @@ struct
     let len = entries * entry_size in
     let buf = Bytes.create len in
     let refill off = ignore (IO.read index.io ~off ~len buf) in
-    let index_end = IO.offset index.io in
+    let index_end = IO.offset ~force:false index.io in
     let fan_out = index.fan_out in
     refill 0L;
     let rec go index_offset buf_offset log_i =
@@ -564,7 +568,7 @@ struct
         match t.index with
         | None -> Tbl.length log.mem
         | Some index ->
-            (Int64.to_int (IO.offset index.io) / entry_size)
+            (Int64.to_int (IO.offset ~force:false index.io) / entry_size)
             + Array.length log_array
       in
       let fan_out = Fan.v ~hash_size:K.hash_size ~entry_size fan_size in
@@ -675,7 +679,10 @@ struct
           in
           append_key_value log.io key value;
           Tbl.replace log.mem key value;
-          Int64.compare (IO.offset log.io) (Int64.of_int t.config.log_size) > 0)
+          Int64.compare
+            (IO.offset ~force:false log.io)
+            (Int64.of_int t.config.log_size)
+          > 0)
     in
     if do_merge then
       ignore (merge ~witness:{ key; key_hash = K.hash key; value } t : _ async)

--- a/src/io.mli
+++ b/src/io.mli
@@ -29,9 +29,9 @@ module type S = sig
 
   val name : t -> string
 
-  val offset : t -> int64
+  val offset : force:bool -> t -> int64
 
-  val force_offset : t -> int64
+  val generation : force:bool -> t -> int64
 
   val readonly : t -> bool
 
@@ -42,10 +42,6 @@ module type S = sig
   val flush : ?with_fsync:bool -> t -> unit
 
   val version : t -> string
-
-  val set_generation : t -> int64 -> unit
-
-  val get_generation : t -> int64
 
   val set_fanout : t -> string -> unit
 

--- a/src/io_array.ml
+++ b/src/io_array.ml
@@ -75,7 +75,7 @@ module Make (IO : Io.S) (Elt : ELT) :
         try get_entry_from_buffer b off with _ -> assert false)
     | _ -> get_entry_from_io t.io off
 
-  let length t = Int64.(div (IO.offset t.io) Elt.encoded_sizeL)
+  let length t = Int64.(div (IO.offset ~force:false t.io) Elt.encoded_sizeL)
 
   let max_buffer_size = 4096
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -35,6 +35,7 @@ module IO : Index.IO = struct
     mutable header : int64;
     mutable raw : Raw.t;
     mutable offset : int64;
+    mutable generation : int64;
     mutable flushed : int64;
     mutable fan_size : int64;
     readonly : bool;
@@ -67,6 +68,7 @@ module IO : Index.IO = struct
     dst.header <- src.header;
     dst.fan_size <- src.fan_size;
     dst.offset <- src.offset;
+    dst.generation <- src.generation;
     dst.flushed <- src.flushed;
     dst.raw <- src.raw
 
@@ -87,22 +89,21 @@ module IO : Index.IO = struct
     if not t.readonly then assert (t.header ++ off <= t.flushed);
     Raw.unsafe_read t.raw ~off:(t.header ++ off) ~len buf
 
-  let offset t = t.offset
-
-  let force_offset t =
-    t.offset <- Raw.Offset.get t.raw;
-    t.offset
+  let offset ~force t =
+    if force then (
+      t.offset <- Raw.Offset.get t.raw;
+      t.offset)
+    else t.offset
 
   let version _ = current_version
 
-  let get_generation t =
-    let i = Raw.Generation.get t.raw in
-    Log.debug (fun m -> m "get_generation: %Ld" i);
-    i
-
-  let set_generation t i =
-    Log.debug (fun m -> m "set_generation: %Ld" i);
-    Raw.Generation.set t.raw i
+  let generation ~force t =
+    if force then (
+      let i = Raw.Generation.get t.raw in
+      Log.debug (fun m -> m "generation: %Ld" i);
+      t.generation <- i;
+      i)
+    else t.generation
 
   let get_fanout t = Raw.Fan.get t.raw
 
@@ -119,6 +120,7 @@ module IO : Index.IO = struct
     let get t =
       let Raw.Header.{ offset; generation; _ } = Raw.Header.get t.raw in
       t.offset <- offset;
+      t.generation <- generation;
       let headers = { offset; generation } in
       Log.debug (fun m -> m "[%s] get_headers: %a" t.file pp headers);
       headers
@@ -157,6 +159,7 @@ module IO : Index.IO = struct
 
   let clear ~generation t =
     t.offset <- 0L;
+    t.generation <- generation;
     t.flushed <- t.header;
     Header.set t { offset = t.offset; generation };
     Raw.Fan.set t.raw "";
@@ -176,12 +179,13 @@ module IO : Index.IO = struct
 
   let v ?(auto_flush_callback = fun () -> ()) ~readonly ~fresh ~generation
       ~fan_size file =
-    let v ~fan_size ~offset raw =
+    let v ~fan_size ~offset ~generation raw =
       let header = 8L ++ 8L ++ 8L ++ 8L ++ fan_size in
       {
         header;
         file;
         offset;
+        generation;
         raw;
         readonly;
         fan_size;
@@ -200,7 +204,7 @@ module IO : Index.IO = struct
         Raw.Fan.set_size raw fan_size;
         Raw.Version.set raw current_version;
         Raw.Generation.set raw generation;
-        v ~fan_size ~offset:0L raw
+        v ~fan_size ~offset:0L ~generation raw
     | true ->
         let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; mode ] 0o644 in
         let raw = Raw.v x in
@@ -211,16 +215,15 @@ module IO : Index.IO = struct
           Raw.Fan.set_size raw fan_size;
           Raw.Version.set raw current_version;
           Raw.Generation.set raw generation;
-          v ~fan_size ~offset:0L raw)
+          v ~fan_size ~offset:0L ~generation raw)
         else
           let version = Raw.Version.get raw in
           if version <> current_version then
             Fmt.failwith "Io.v: unsupported version %s (current version is %s)"
               version current_version;
-
-          let offset = Raw.Offset.get raw in
+          let { Raw.Header.offset; generation; _ } = Raw.Header.get raw in
           let fan_size = Raw.Fan.get_size raw in
-          v ~fan_size ~offset raw
+          v ~fan_size ~offset ~generation raw
 
   type lock = { path : string; fd : Unix.file_descr }
 


### PR DESCRIPTION
- Remove IO.set_generation, IO.get_generation and IO.force_offset
- Change IO.offset to take a `force` arguement
  (`IO.offset ~force:true` was `IO.force_offset`,
   `IO.offset ~force:false` was `IO.offset`)
- Add `IO.generation`. `IO.generation ~force:true` was `IO.get_generation`
  and add `IO.generation ~force:false` to return the cached generation number