### PR TITLE
Add an option to choose overcommiting memory instead of blocking writes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - Added `is_merging` to detect if a merge is running. (#192)
 - New `IO.Header.{get,set}` functions to read and write the file headers
   atomically (#175, #204, @icristescu, @CraigFe, @samoht)
+- Added a `throttle` configuration option to select the strategy to use
+  when the cache are full and an async merge is already in progress. The
+  current behavior is the (default) [`Block_writes] strategy. The new
+  [`Overcommit_memory] does not block but continue to fill the cache instead.
+  (#209, @samoht)
 
 ## Changed
 
@@ -16,7 +21,6 @@
   than waiting for it to finish. (#185)
 - `sync` has to be called by the read-only instance to synchronise with the
   files on disk. (#175)
-
 - Caching of `Index` instances is now explicit: `Index.Make` requires a cache
   implementation, and `Index.v` may be passed a cache to be used for instance
   sharing. The default behaviour is _not_ to share instances. (#188)

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -128,6 +128,7 @@ module type S = sig
     ?cache:cache ->
     ?fresh:bool ->
     ?readonly:bool ->
+    ?throttle:[ `Overcommit_memory | `Block_writes ] ->
     log_size:int ->
     string ->
     t
@@ -137,6 +138,10 @@ module type S = sig
       @param cache used for instance sharing.
       @param fresh whether an existing index should be overwritten.
       @param read_only whether read-only mode is enabled for this index.
+      @param throttle the strategy to use when the cache are full and and async
+      in already in progress. [Block_writes] (the default) blocks any new writes
+      until the merge is completed. [Overcommit_memory] does not block but
+      continues to fill the (already full) cache.
       @param log_size the maximum number of bindings in the `log` IO. *)
 
   val clear : t -> unit

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -34,11 +34,17 @@ end) : sig
   val fresh_name : string -> string
   (** [fresh_name typ] is a clean directory for a resource of type [typ]. *)
 
-  val with_empty_index : unit -> (t -> 'a) -> 'a
+  val with_empty_index :
+    ?throttle:[ `Overcommit_memory | `Block_writes ] -> unit -> (t -> 'a) -> 'a
   (** [with_empty_index f] applies [f] to a fresh empty index. Afterwards, the
       index and any clones are closed. *)
 
-  val with_full_index : ?size:int -> unit -> (t -> 'a) -> 'a
+  val with_full_index :
+    ?throttle:[ `Overcommit_memory | `Block_writes ] ->
+    ?size:int ->
+    unit ->
+    (t -> 'a) ->
+    'a
   (** [with_full_index f] applies [f] to a fresh index with a random table of
       key/value pairs. [f] also gets a constructor for opening clones of the
       index at the same location. Afterwards, the index and any clones are

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -485,7 +485,9 @@ module Close = struct
 
   (** [close] terminates an ongoing merge operation *)
   let aborted_merge () =
-    let* Context.{ rw; _ } = Context.with_full_index ~size:100 () in
+    let* Context.{ rw; _ } =
+      Context.with_full_index ~throttle:`Block_writes ~size:100 ()
+    in
     let close_request, abort_signalled =
       (* Both locks are initially held.
          - [close_request] is dropped by the merge thread in the [`Before] hook


### PR DESCRIPTION
This only happens when there is an async merge in progress and that the
caches are already full.

Fix #201 

This should probably be the default (and a `close` test should be changed to use `Block_writes`)