### PR TITLE
Index.clear should cancel any concurrent Index.merge

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -120,7 +120,7 @@ struct
         Tbl.clear log.mem;
         may
           (fun l ->
-            IO.clear ~generation:t.generation log.io;
+            IO.clear ~generation:t.generation l.io;
             IO.close l.io)
           t.log_async;
         may

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -287,6 +287,8 @@ module type Index = sig
           concurrent merge operations, but {i before} blocking on those
           cancellations having completed. *)
 
+      val clear' : hook:[ `Abort_signalled ] Hook.t -> t -> unit
+
       type 'a async
       (** The type of asynchronous computation. *)
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -31,7 +31,7 @@ module IO : Index.IO = struct
   let ( -- ) = Int64.sub
 
   type t = {
-    file : string;
+    mutable file : string;
     mutable header : int64;
     mutable raw : Raw.t;
     mutable offset : int64;
@@ -64,6 +64,7 @@ module IO : Index.IO = struct
     Raw.close dst.raw;
     Unix.rename src.file dst.file;
     Buffer.clear dst.buf;
+    src.file <- dst.file;
     dst.header <- src.header;
     dst.fan_size <- src.fan_size;
     dst.offset <- src.offset;

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -164,15 +164,6 @@ module IO : Index.IO = struct
     Buffer.clear t.buf;
     Raw.fsync t.raw
 
-  let buffers = Hashtbl.create 256
-
-  let buffer file =
-    try Hashtbl.find buffers file
-    with Not_found ->
-      let buf = Buffer.create (4 * 1024) in
-      Hashtbl.add buffers file buf;
-      buf
-
   let () = assert (String.length current_version = 8)
 
   let v ?(auto_flush_callback = fun () -> ()) ~readonly ~fresh ~generation
@@ -186,7 +177,7 @@ module IO : Index.IO = struct
         raw;
         readonly;
         fan_size;
-        buf = buffer file;
+        buf = Buffer.create (4 * 1024);
         flushed = header ++ offset;
         auto_flush_callback;
       }


### PR DESCRIPTION
We want `clear` to be fast and it doesn't matter if we wait for any
async merges to complete as we will empty the entries anyway.

Fix #202