### PR TITLE
Test abort merges after one entry added

### DIFF
--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -293,7 +293,7 @@ module type Index = sig
       (** The type of asynchronous computation. *)
 
       val force_merge :
-        ?hook:[ `After | `After_clear | `Before ] Hook.t ->
+        ?hook:[ `After | `After_clear | `After_first_entry | `Before ] Hook.t ->
         t ->
         [ `Completed | `Aborted ] async
       (** [force_merge t] forces a merge for [t]. Optionally, a hook can be
@@ -303,6 +303,8 @@ module type Index = sig
             lock);
           - [`After_clear]: immediately after clearing the log, at the end of a
             merge;
+          - [`After_first_entry]: immediately after adding the first entry in
+            the merge file, if the data file contains at least one entry;
           - [`After]: immediately after merging (while holding the merge lock). *)
 
       val await : 'a async -> ('a, [ `Async_exn of exn ]) result

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -548,7 +548,7 @@ module Close = struct
       | `Before ->
           Fmt.pr "Child: issuing request to close the index\n%!";
           Mutex.unlock close_request
-      | `After_clear | `After ->
+      | `After_clear | `After | `After_first_entry ->
           Alcotest.fail "Merge completed despite concurrent close"
     in
     let merge_promise : _ Index.async =


### PR DESCRIPTION
This test reproduces the failing test of https://github.com/mirage/index/pull/214, but uses close instead of clear to abort the merge.

The fix is to [not cache buffers](https://github.com/mirage/index/pull/211/files#diff-24b617c6b01eb5122d1e4e45357860c6R180) which is already included in https://github.com/mirage/index/pull/211. 