### PR TITLE
Remove unused IO fields

### DIFF
--- a/src/io.mli
+++ b/src/io.mli
@@ -27,23 +27,13 @@ module type S = sig
     string ->
     t
 
-  val name : t -> string
-
   val offset : t -> int64
-
-  val force_offset : t -> int64
-
-  val readonly : t -> bool
 
   val read : t -> off:int64 -> len:int -> bytes -> int
 
   val clear : generation:int64 -> t -> unit
 
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
-
-  val version : t -> string
-
-  val set_generation : t -> int64 -> unit
 
   val get_generation : t -> int64
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -57,8 +57,6 @@ module IO : Index.IO = struct
       t.flushed <- offset ++ t.header);
     if with_fsync then Raw.fsync t.raw
 
-  let name t = t.file
-
   let rename ~src ~dst =
     flush ~with_fsync:true src;
     Raw.close dst.raw;
@@ -90,20 +88,10 @@ module IO : Index.IO = struct
 
   let offset t = t.offset
 
-  let force_offset t =
-    t.offset <- Raw.Offset.get t.raw;
-    t.offset
-
-  let version _ = current_version
-
   let get_generation t =
     let i = Raw.Generation.get t.raw in
     Log.debug (fun m -> m "get_generation: %Ld" i);
     i
-
-  let set_generation t i =
-    Log.debug (fun m -> m "set_generation: %Ld" i);
-    Raw.Generation.set t.raw i
 
   let get_fanout t = Raw.Fan.get t.raw
 
@@ -125,13 +113,11 @@ module IO : Index.IO = struct
       headers
 
     let set t { offset; generation } =
-      let version = version () in
+      let version = current_version in
       Log.debug (fun m ->
           m "[%s] set_header %a" t.file pp { offset; generation });
       Raw.Header.(set t.raw { offset; version; generation })
   end
-
-  let readonly t = t.readonly
 
   let protect_unix_exn = function
     | Unix.Unix_error _ as e -> failwith (Printexc.to_string e)


### PR DESCRIPTION
In the process of working on https://github.com/mirage/index/pull/219, I noticed that there are quite a few unused IO endpoints. This removes them.