### PR TITLE
Use full unsigned int64 hashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 - Caching of `Index` instances is now explicit: `Index.Make` requires a cache
   implementation, and `Index.v` may be passed a cache to be used for instance
   sharing. The default behaviour is _not_ to share instances. (#188)
+- Module `Key` does not require `hash_size` anymore; function `hash` now returns
+  `int64` hashes and is required to be evenly distributed over 64 bits. (#222)
 
 ## Fixed
 

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -45,9 +45,8 @@ module Context = struct
 
     let v () = random_string key_size
 
-    let hash = Hashtbl.hash
-
-    let hash_size = 30
+    let hash x =
+      Hashtbl.hash x |> Int64.of_int |> fun h -> Int64.shift_left h (64 - 30)
 
     let encode s = s
 

--- a/src/fan.mli
+++ b/src/fan.mli
@@ -20,17 +20,17 @@ type t
 val equal : t -> t -> bool
 (** The equality function for fan-out. *)
 
-val v : hash_size:int -> entry_size:int -> int -> t
+val v : entry_size:int -> int -> t
 (** [v ~hash_size ~entry_size n] creates a fan_out for an index with [hash_size]
     and [entry_size], containing [n] elements. *)
 
 val nb_fans : t -> int
 (** [nb_fans t] is the number of fans in [t]. *)
 
-val search : t -> int -> int64 * int64
+val search : t -> int64 -> int64 * int64
 (** [search t hash] is the interval of offsets containing [hash], if present. *)
 
-val update : t -> int -> int64 -> unit
+val update : t -> hash:int64 -> offset:int64 -> unit
 (** [update t hash off] updates [t] so that [hash] is registered to be at offset
     [off]. *)
 
@@ -45,7 +45,7 @@ val exported_size : t -> int
 val export : t -> string
 (** [export t] is a string encoded form of [t]. *)
 
-val import : hash_size:int -> string -> t
+val import : string -> t
 (** [import ~hash_size buf] decodes [buf] such that
     [import ~hash_size (export t) = t] if [t] was initially created with
     ~hash_size. *)

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -22,15 +22,8 @@ module type Key = sig
   val equal : t -> t -> bool
   (** The equality function for keys. *)
 
-  val hash : t -> int
-  (** Note: Unevenly distributed hash functions may result in performance drops. *)
-
-  val hash_size : int
-  (** The number of bits necessary to encode the maximum output value of
-      {!hash}. `Hashtbl.hash` uses 30 bits.
-
-      Overestimating the [hash_size] will result in performance drops;
-      underestimation will result in undefined behavior. *)
+  val hash : t -> int64
+  (** Note: This function is required to be evenly distributed on 64 bits. *)
 
   val encode : t -> string
   (** [encode] is an encoding function. The resultant encoded values must have

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -1,8 +1,6 @@
 open Crowbar
 module Fan = Index.Private.Fan
 
-let hash_size = 30
-
 let entry_size = 56
 
 let entry_sizeL = Int64.of_int entry_size
@@ -11,12 +9,12 @@ let int_bound = 100_000_000
 
 let bounded_int = map [ int ] (fun i -> abs i mod int_bound)
 
-let hash = map [ bytes ] Hashtbl.hash
+let hash = int64
 
-let hash_list = map [ list hash ] (List.sort compare)
+let hash_list = map [ list hash ] (List.sort Int64.unsigned_compare)
 
 let empty_fan_with_size =
-  map [ bounded_int ] (fun n -> (Fan.v ~hash_size ~entry_size n, n))
+  map [ bounded_int ] (fun n -> (Fan.v ~entry_size n, n))
 
 let empty_fan = map [ empty_fan_with_size ] fst
 
@@ -29,7 +27,7 @@ let update_list =
 
 let fan_with_updates =
   map [ empty_fan; update_list ] (fun fan l ->
-      List.iter (fun (hash, off) -> Fan.update fan hash off) l;
+      List.iter (fun (hash, offset) -> Fan.update fan ~hash ~offset) l;
       Fan.finalize fan;
       (fan, l))
 
@@ -42,7 +40,7 @@ let check_export_size fan =
 
 let check_export fan =
   let exported = Fan.export fan in
-  let imported = Fan.import ~hash_size exported in
+  let imported = Fan.import exported in
   check_eq ~eq:Fan.equal imported fan
 
 let check_updates (fan, updates) =
@@ -50,11 +48,8 @@ let check_updates (fan, updates) =
     (fun (hash, off) ->
       let low, high = Fan.search fan hash in
       if off < low || high < off then
-        (* Use Crowbar.failf on next release *)
-        fail
-          (Printf.sprintf
-             "hash %d was added at off %Ld, but got low=%Ld, high=%Ld" hash off
-             low high))
+        Crowbar.failf "hash %Ld was added at off %Ld, but got low=%Ld, high=%Ld"
+          hash off low high)
     updates
 
 let check_fan_size (fan, size) =

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -41,9 +41,8 @@ module Key = struct
 
   let v = random_string
 
-  let hash = Hashtbl.hash
-
-  let hash_size = 30
+  let hash x =
+    Hashtbl.hash x |> Int64.of_int |> fun h -> Int64.shift_left h (64 - 30)
 
   let encode s = s
 


### PR DESCRIPTION
This PR removes the `hash_size` value in the input `Key` functor, and requires a `hash: t -> int64` function that is well distributed over all the 64 bits.
This `int64` value will always be interpreted as *unsigned*.

This breaks the on-disk format because it used these hashes to order the bindings in `data`. 
This means the version of the format should change and a migration function (that performs an external sort) should be provided.
