### PR TITLE
OCamlFormat: use conventional profile

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
 version = 0.15.0
+profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters = no


### PR DESCRIPTION
We dropped the `profile = conventional` line when it became default in `ocamlformat.0.12`. However, this causes any global config files on developer machines to override the "defaults" inside projects. This has consequences for reproducibility of formatting on different machines, so we should explicitly set the profile for now.

For more details, see the following upstream issue: https://github.com/ocaml-ppx/ocamlformat/issues/1459.