### PR TITLE
Fix generation of log_async

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -586,7 +586,7 @@ struct
       let io =
         let log_async_path = log_async_path t.root in
         IO.v ~flush_callback:t.config.flush_callback ~fresh:true ~readonly:false
-          ~generation:(Int64.succ t.generation) ~fan_size:0L log_async_path
+          ~generation:t.generation ~fan_size:0L log_async_path
       in
       let mem = Tbl.create 0 in
       { io; mem }
@@ -680,7 +680,7 @@ struct
 
               t.log_async <- None);
 
-          IO.clear ~generation:(Int64.succ generation) log_async.io;
+          IO.clear ~generation log_async.io;
           IO.close log_async.io;
           hook `After;
           Mutex.unlock t.merge_lock;

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -119,8 +119,8 @@ let check_completed = function
   | Ok `Completed -> ()
   | Ok `Aborted -> Alcotest.fail "Unexpected asynchronous abort"
   | Error (`Async_exn exn) ->
-     Alcotest.failf "Unexpected asynchronous exception: %s"
-       (Printexc.to_string exn)
+      Alcotest.failf "Unexpected asynchronous exception: %s"
+        (Printexc.to_string exn)
 
 module Make_context (Config : sig
   val root : string


### PR DESCRIPTION
I noticed while running layered store benchmarks, that the log_async file is read from scratch at every sync call. This is because, if the generation of log_async differs from the generation of the instance then log_async is [refilled from offset 0](https://github.com/mirage/index/blob/master/src/index.ml#L271). With the overcommit option, the log_async can get quite large, so this sync from scratch can take a lot of time (2s in my benchs for every RO sync call). 

This PR is an effort to make the generations consistent between log and log_async, and this makes my benchmarks better. However, it is hard to add test for this, and we do not yet have benchmarks in index that use both RW and RO instances to spot the regression.
