### PR TITLE
Use crowbar.0.2

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -25,7 +25,7 @@ depends: [
   "logs"
   "mtime"   {>= "1.0.0"}
   "alcotest" {with-test}
-  "crowbar" {with-test}
+  "crowbar" {with-test & >= "0.2"}
   "re" {with-test}
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"

--- a/test/fuzz/fan/dune
+++ b/test/fuzz/fan/dune
@@ -14,4 +14,4 @@
   main.exe
   (source_tree ../input))
  (action
-  (run afl-fuzz -i ../input -o output ./main.exe @@)))
+  (run afl-fuzz -i ../input -o output -m 2048 ./main.exe @@)))

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -50,18 +50,14 @@ let check_updates (fan, updates) =
     (fun (hash, off) ->
       let low, high = Fan.search fan hash in
       if off < low || high < off then
-        (* Use Crowbar.failf on next release *)
-        fail
-          (Printf.sprintf
-             "hash %d was added at off %Ld, but got low=%Ld, high=%Ld" hash off
-             low high))
+        failf "hash %d was added at off %Ld, but got low=%Ld, high=%Ld" hash off
+          low high)
     updates
 
 let check_fan_size (fan, size) =
   let nb_fans = Fan.nb_fans fan in
   let fan_size = size / nb_fans in
-  if fan_size * entry_size > 4096 then
-    fail (Printf.sprintf "Fan size is too big: %d" fan_size)
+  if fan_size * entry_size > 4096 then failf "Fan size is too big: %d" fan_size
 
 let () =
   add_test ~name:"Export size" [ fan ] check_export_size;


### PR DESCRIPTION
Just picking the printers from version 0.2.
Also increasing the memory limit as the default 50MB won't be enough for these tests and will trigger (out of memory) errors.