### PR TITLE
Move log_async clear under rename_lock.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 
 - Added values after a clear are found by read-only instances. (#168)
 - Fix a race between `merge` and `sync` (#203, @samoht, @CraigFe)
+- Fix a potential loss of data if a crash occurs at the end of a merge (#232)
 
 # 1.2.1 (2020-06-24)
 


### PR DESCRIPTION
This will prevent values from being added to the log before the log_async is cleared, as those values could possibly be discarded on next startup if a crash occured and the log_async was considered not empty.