### PR TITLE
Add IO.exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   [`Overcommit_memory] does not block but continue to fill the cache instead.
   (#209, @samoht)
 
+- Add `IO.exists` obligation for IO implementations, to be used for lazy
+  creation of IO instances. (#233, @CraigFe)
+
 ## Changed
 
 - `Index.close` will now abort an ongoing asynchronous merge operation, rather

--- a/src/io.mli
+++ b/src/io.mli
@@ -60,4 +60,8 @@ module type S = sig
 
     val get : t -> header
   end
+
+  val exists : string -> bool
+  (** [exists name] is true iff there is a pre-existing IO instance called
+      [name]. *)
 end

--- a/src/layout.ml
+++ b/src/layout.ml
@@ -1,0 +1,11 @@
+let toplevel ~root name = Filename.(concat (concat root "index") name)
+
+let log = toplevel "log"
+
+let log_async = toplevel "log_async"
+
+let data = toplevel "data"
+
+let lock = toplevel "lock"
+
+let merge = toplevel "merge"

--- a/src/layout.mli
+++ b/src/layout.mli
@@ -1,0 +1,11 @@
+(** Defines the namespacing of the various IO instances required by Index. *)
+
+val log : root:string -> string
+
+val log_async : root:string -> string
+
+val data : root:string -> string
+
+val lock : root:string -> string
+
+val merge : root:string -> string

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -200,6 +200,8 @@ module IO : Index.IO = struct
           let fan_size = Raw.Fan.get_size raw in
           v ~fan_size ~offset raw
 
+  let exists = Sys.file_exists
+
   type lock = { path : string; fd : Unix.file_descr }
 
   exception Locked of string


### PR DESCRIPTION
... and remove calls to `Sys.file_exists` inside the `index` package, which is supposed to be platform-agnostic.

Also extracts namespacing choices to a new module, `Layout`. This will be more obviously useful when we add integrity-checking utilities that must know about the FS structure without necessarily relying on the entire implementation of Index.