### PR TITLE
Make Index.close merge termination logic opt-in

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,12 @@
 - Add `IO.exists` obligation for IO implementations, to be used for lazy
   creation of IO instances. (#233, @CraigFe)
 
+- `Index.close` now takes an `~immediately:()` argument. When passed, this
+  causes `close` to terminate any ongoing asynchronous merge operation, rather
+  than waiting for it to finish. (#185, #234)
+
 ## Changed
 
-- `Index.close` will now abort an ongoing asynchronous merge operation, rather
-  than waiting for it to finish. (#185)
 - `sync` has to be called by the read-only instance to synchronise with the
   files on disk. (#175)
 - Caching of `Index` instances is now explicit: `Index.Make` requires a cache

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -191,9 +191,13 @@ module type S = sig
       - If [with_fsync] is [true], this also flushes the OS caches for each [IO]
         instance. *)
 
-  val close : t -> unit
+  val close : ?immediately:unit -> t -> unit
   (** Closes all resources used by [t], flushing any internal buffers in the
-      instance. *)
+      instance.
+
+      If [immediately] is passed, this operation will abort any ongoing
+      background processes. This guarantees not to corrupt the store, but may
+      require additional work to be done on the next startup. *)
 
   val sync : t -> unit
   (** [sync t] syncs a read-only index with the files on disk. Raises
@@ -319,7 +323,8 @@ module type Index = sig
       (** [replace' t k v] is like {!replace t k v} but returns a promise of a
           merge result if the {!replace} call triggered one. *)
 
-      val close' : hook:[ `Abort_signalled ] Hook.t -> t -> unit
+      val close' :
+        hook:[ `Abort_signalled ] Hook.t -> ?immediately:unit -> t -> unit
       (** [`Abort_signalled]: after the cancellation signal has been sent to any
           concurrent merge operations, but {i before} blocking on those
           cancellations having completed. *)

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -353,7 +353,7 @@ let add_bindings index =
   let k1, v1 = (Key.v (), Value.v ()) in
   Index.replace index k1 v1
 
-(** Test that a clear is aborting the merge.*)
+(** Test that a clear aborts the merge. *)
 let test_non_blocking_clear () =
   let* Context.{ rw; _ } = Context.with_empty_index () in
   let lock () =
@@ -418,7 +418,8 @@ let test_abort_merge ~abort_merge () =
 
 let test_clear_aborts_merge = test_abort_merge ~abort_merge:Index.clear'
 
-let test_close_aborts_merge = test_abort_merge ~abort_merge:Index.close'
+let test_close_immediately_aborts_merge =
+  test_abort_merge ~abort_merge:(Index.close' ~immediately:())
 
 let tests =
   [
@@ -434,6 +435,8 @@ let tests =
     ("merge during ro sync", `Quick, merge_during_sync);
     ("is_merging", `Quick, test_is_merging);
     ("clear is not blocking", `Quick, test_non_blocking_clear);
-    ("close aborts merge", `Quick, test_close_aborts_merge);
-    ("clear aborts merge", `Quick, test_clear_aborts_merge);
+    ("`clear` aborts merge", `Quick, test_clear_aborts_merge);
+    ( "`close ~immediately` aborts merge",
+      `Quick,
+      test_close_immediately_aborts_merge );
   ]


### PR DESCRIPTION
When developing the offline integrity-checking tool for Index, I noticed that the following simple usage of Index is non-deterministic:

```ocaml
let random () =
  let index = Index.v ~fresh:true ~log_size:100 "data/random" in
  for _ = 1 to 1001 do
    Index.replace index (random ()) (random ())
  done;
  Index.close index
```

In particular, the `Index.close` call may or may not cancel an ongoing merge operation, meaning that we cannot know what files will exist on disk after running this code. After pondering on it for a bit, I think this behaviour of `close` should be opt-in. This PR does exactly that.