### PR TITLE
Add capabilities to the fanout

### DIFF
--- a/src/fan.ml
+++ b/src/fan.ml
@@ -15,7 +15,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
-type t = { fans : int64 array; mask : int; shift : int }
+type 'a t = { fans : int64 array; mask : int; shift : int }
 
 let equal t t' =
   let rec loop i =
@@ -59,7 +59,8 @@ let finalize t =
       if t.fans.(i) = 0L then t.fans.(i) <- curr;
       loop t.fans.(i) (i + 1))
   in
-  loop 0L 0
+  loop 0L 0;
+  (t :> [ `Read ] t)
 
 external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64u"
 

--- a/src/fan.mli
+++ b/src/fan.mli
@@ -15,37 +15,37 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
-type t
+type 'a t
 
-val equal : t -> t -> bool
-(** The equality function for fan-out. *)
+val equal : 'a t -> 'a t -> bool
+(** The equality function for fanouts. *)
 
-val v : hash_size:int -> entry_size:int -> int -> t
+val v : hash_size:int -> entry_size:int -> int -> [ `Write ] t
 (** [v ~hash_size ~entry_size n] creates a fan_out for an index with [hash_size]
     and [entry_size], containing [n] elements. *)
 
-val nb_fans : t -> int
+val nb_fans : 'a t -> int
 (** [nb_fans t] is the number of fans in [t]. *)
 
-val search : t -> int -> int64 * int64
+val search : [ `Read ] t -> int -> int64 * int64
 (** [search t hash] is the interval of offsets containing [hash], if present. *)
 
-val update : t -> int -> int64 -> unit
+val update : [ `Write ] t -> int -> int64 -> unit
 (** [update t hash off] updates [t] so that [hash] is registered to be at offset
     [off]. *)
 
-val finalize : t -> unit
-(** Finalizes the update of the fanout. This is mendatory before any [search]
+val finalize : [ `Write ] t -> [ `Read ] t
+(** Finalizes the update of the fanout. This is mandatory before any [search]
     query. *)
 
-val exported_size : t -> int
+val exported_size : 'a t -> int
 (** [exported_size t] is the size of [export t]. This does not actually compute
     the encoding of [t]. *)
 
-val export : t -> string
+val export : [ `Read ] t -> string
 (** [export t] is a string encoded form of [t]. *)
 
-val import : hash_size:int -> string -> t
+val import : hash_size:int -> string -> [ `Read ] t
 (** [import ~hash_size buf] decodes [buf] such that
     [import ~hash_size (export t) = t] if [t] was initially created with
     ~hash_size. *)

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -30,7 +30,7 @@ let update_list =
 let fan_with_updates =
   map [ empty_fan; update_list ] (fun fan l ->
       List.iter (fun (hash, off) -> Fan.update fan hash off) l;
-      Fan.finalize fan;
+      let fan = Fan.finalize fan in
       (fan, l))
 
 let fan = map [ fan_with_updates ] fst


### PR DESCRIPTION
The `Fan` module only works with the following workflow:
- Do a lot of `update`
- Do a `finalize`
- Do a lot of `search`

This PR makes this workflow appear in the types and ensures the invariant is verified.﻿
