### PR TITLE
Add bench target to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test doc examples
+.PHONY: all clean test doc examples bench
 
 all:
 	dune build
@@ -14,3 +14,6 @@ clean:
 
 doc:
 	dune build @doc
+
+bench:
+	@dune exec -- ./bench/bench.exe --json --minimal


### PR DESCRIPTION
The pipeline can use a standard `make bench` across all different projects now!