### PR TITLE
Use Semaphore compatibility library

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -31,6 +31,7 @@ depends: [
   "alcotest" {with-test}
   "crowbar" {with-test & >= "0.2"}
   "re" {with-test}
+  "semaphore-compat"
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""
@@ -48,4 +49,5 @@ pin-depends: [
   [ "repr.dev"       "git+https://github.com/CraigFe/repr#b705653a96614787966b9dd63d071576ad18a2c9" ]
   [ "ppx_repr.dev"   "git+https://github.com/CraigFe/repr#b705653a96614787966b9dd63d071576ad18a2c9" ]
   [ "progress.dev"   "git+https://github.com/CraigFe/progress.git#abed69070bc5c10003af1fbbc50ea2ca83877de6" ]
+  [ "semaphore-compat.dev"  "git+https://github.com/CraigFe/semaphore-compat.git#cf69daf0c55c9e92130e409de0dfd1dcf9c9dc2f" ]
 ]

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -34,7 +34,9 @@ module type SEMAPHORE = sig
   (** The type of binary semaphore. *)
 
   val make : bool -> t
-  (** Return a fresh semaphore with the given initial state. *)
+  (** [make b] returns a new semaphore with the given initial state. If [b] is
+      [true], the semaphore is initially available for acquisition; otherwise,
+      the semaphore is initially unavailable. *)
 
   val acquire : t -> unit
   (** Acquire the given semaphore. Acquisition is not re-entrant. *)

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -4,4 +4,4 @@
   (names pread pwrite))
  (public_name index.unix)
  (name index_unix)
- (libraries fmt index logs logs.threaded threads.posix unix))
+ (libraries fmt index logs logs.threaded threads.posix unix semaphore-compat))

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -211,8 +211,3 @@ let check_disjoint index htbl =
           Alcotest.failf "Found value %a when checking for the absence of %a"
             (Repr.pp Value.t) v' pp_binding (k, v))
     htbl
-
-let locked_mutex () =
-  let m = Mutex.create () in
-  Mutex.lock m;
-  m

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -107,5 +107,3 @@ val check_completed :
 val check_equivalence : Index.t -> (Key.t, Value.t) Hashtbl.t -> unit
 
 val check_disjoint : Index.t -> (Key.t, Value.t) Hashtbl.t -> unit
-
-val locked_mutex : unit -> Mutex.t

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -2,4 +2,4 @@
  (names main force_merge io_array)
  (package index)
  (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims
-   threads.posix repr))
+   threads.posix repr semaphore-compat))


### PR DESCRIPTION
Our usage of the `Mutex` module in the UNIX implementation of Index previously relied upon undefined behaviours of `glibc`, which caused Index to be incompatible with FreeBSD. In particular, we were relying on being able to release a mutex from a thread that did not itself take the mutex (in order to implement the merge lock).

This commit replaces the usage of `Mutex` with a dependency on the `semaphore-compat` library, which provides a shim of the `Semaphore` module to be released in OCaml 4.12. In particular, the mutual-exclusion semantics that we require are provided by the binary semaphores in this library.