### PR TITLE
Expose Cmdliner terms of the integrity-checking binary

### DIFF
--- a/src/checks_intf.ml
+++ b/src/checks_intf.ml
@@ -1,6 +1,23 @@
 type empty = |
 
 module type S = sig
+  module Stat : sig
+    val run : root:string -> unit
+    (** Read basic metrics from an existing store. *)
+
+    val term : (unit -> unit) Cmdliner.Term.t
+    (** A pre-packaged [Cmdliner] term for executing {!run}. *)
+  end
+
+  module Integrity_check : sig
+    val run : root:string -> unit
+    (** Check that the integrity invariants of a store are preserved, and
+        display any broken invariants. *)
+
+    val term : (unit -> unit) Cmdliner.Term.t
+    (** A pre-packaged [Cmdliner] term for executing {!run}. *)
+  end
+
   val cli : unit -> empty
   (** Run a [Cmdliner] binary containing tools for running offline integrity
       checks. *)

--- a/test/cli/index-fsck-help.txt
+++ b/test/cli/index-fsck-help.txt
@@ -5,7 +5,7 @@ SYNOPSIS
        index-fsck COMMAND ...
 
 COMMANDS
-       check
+       integrity-check
            Search the store for integrity faults and corruption.
 
        stat


### PR DESCRIPTION
This is the `index` counterpart of https://github.com/mirage/irmin/pull/1141, working towards pulling these endpoints together in a `tezos-node storage` subcommand.