### PR TITLE
Add an overcommit option in replace to postpone merges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@
 - Added `Index.Checks.cli`, which provides offline integrity checking of Index
   stores. (#236)
 
+- `Index.replace` now takes a `~overcommit` argument to postpone a merge. (#253)
+
+- `Index.merge` is now part of the public API. (#253)
+
 ## Changed
 
 - `sync` has to be called by the read-only instance to synchronise with the

--- a/src/index.ml
+++ b/src/index.ml
@@ -727,7 +727,7 @@ struct
     if t.config.readonly then raise RO_not_allowed;
     instance_is_merging t
 
-  let replace' ?hook t key value =
+  let replace' ?hook ?(overcommit = false) t key value =
     let t = check_open t in
     Stats.incr_nb_replace ();
     Log.debug (fun l ->
@@ -745,7 +745,8 @@ struct
           Tbl.replace log.mem key value;
           Int64.compare (IO.offset log.io) (Int64.of_int t.config.log_size) > 0)
     in
-    if log_limit_reached then
+    if overcommit then None
+    else if log_limit_reached then
       let is_merging = instance_is_merging t in
       match (t.config.throttle, is_merging) with
       | `Overcommit_memory, true ->
@@ -756,8 +757,8 @@ struct
           Some (merge ?hook ~witness:(Entry.v key value) t)
     else None
 
-  let replace t key value =
-    ignore (replace' ?hook:None t key value : _ async option)
+  let replace ?overcommit t key value =
+    ignore (replace' ?hook:None ?overcommit t key value : _ async option)
 
   let replace_with_timer ?sampling_interval t key value =
     if sampling_interval <> None then Stats.start_replace ();

--- a/src/index.ml
+++ b/src/index.ml
@@ -747,8 +747,7 @@ struct
           Tbl.replace log.mem key value;
           Int64.compare (IO.offset log.io) (Int64.of_int t.config.log_size) > 0)
     in
-    if overcommit then None
-    else if log_limit_reached then
+    if log_limit_reached && not overcommit then
       let is_merging = instance_is_merging t in
       match (t.config.throttle, is_merging) with
       | `Overcommit_memory, true ->

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -130,7 +130,10 @@ module type S = sig
 
   val replace : ?overcommit:bool -> t -> key -> value -> unit
   (** [replace t k v] binds [k] to [v] in [t], replacing any existing binding of
-      [k]. *)
+      [k].
+
+      If [overcommit] is true, the operation does not triger a merge, even if
+      the caches are full. By default [overcommit] is false. *)
 
   val filter : t -> (key * value -> bool) -> unit
   (** [filter t p] removes all the bindings (k, v) that do not satisfy [p]. This
@@ -170,7 +173,14 @@ module type S = sig
       {!RO_not_allowed} if called by a read-only index. *)
 
   val merge : t -> unit
-  (** [merge] forces a merge for [t]. *)
+  (** [merge t] forces a merge for [t].
+
+      If there is no merge running, this operation is non-blocking, i.e. it
+      returns immediately, with the merge running concurrently.
+
+      If a merge is running already, this operation blocks until the previous
+      merge is complete. It then launches a merge (which runs concurrently) and
+      returns. *)
 
   (** Offline [fsck]-like utility for checking the integrity of Index stores
       built using this module. *)

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -128,7 +128,7 @@ module type S = sig
   val mem : t -> key -> bool
   (** [mem t k] is [true] iff [k] is bound in [t]. *)
 
-  val replace : t -> key -> value -> unit
+  val replace : ?overcommit:bool -> t -> key -> value -> unit
   (** [replace t k v] binds [k] to [v] in [t], replacing any existing binding of
       [k]. *)
 
@@ -205,6 +205,7 @@ module type Private = sig
 
   val replace' :
     ?hook:[ `Merge of merge_stages ] hook ->
+    ?overcommit:bool ->
     t ->
     key ->
     value ->

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -169,6 +169,9 @@ module type S = sig
   (** [is_merging t] returns true if [t] is running a merge. Raises
       {!RO_not_allowed} if called by a read-only index. *)
 
+  val merge : t -> unit
+  (** [merge] forces a merge for [t]. *)
+
   (** Offline [fsck]-like utility for checking the integrity of Index stores
       built using this module. *)
   module Checks : sig


### PR DESCRIPTION
Experimenting with adding more control over merges from the freeze thread in irmin-pack. For now the irmin-pack benchmarks look promising:
- the spikes are the freezes that block waiting for previous freeze to complete
![freezes](https://user-images.githubusercontent.com/16655454/101332672-e2109a00-3875-11eb-905f-26f58474e0b9.png)
- if we remove the spike due to freezes and only look at the time for the rest of the commits:
![wo_freezes](https://user-images.githubusercontent.com/16655454/101332678-e3da5d80-3875-11eb-82fc-95f7264176f0.png)

On top of https://github.com/mirage/index/pull/251.