### PR TITLE
Rename Index.force_merge into Index.try_merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
 
 - `Index.merge` is now part of the public API. (#253)
 
+- `Index.try_merge` is now part of the public API. `try_merge' is a no-op if
+  the number of entries in the write-ahead log is smaller than [log_size],
+  otherwise it's `merge'. (#253 @samoht)
+
 ## Changed
 
 - `sync` has to be called by the read-only instance to synchronise with the

--- a/src/index.ml
+++ b/src/index.ml
@@ -550,13 +550,13 @@ struct
       !n
 
   let merge' ?(blocking = false) ?(filter = fun _ -> true) ?(hook = fun _ -> ())
-      ~witness ?(forced = false) t =
+      ~witness ?(force = false) t =
     let yield () = check_pending_cancel t in
     Semaphore.acquire t.merge_lock;
     let merge_id = merge_counter () in
     let merge_start_time = Mtime_clock.counter () in
     Log.info (fun l ->
-        let pp_forced ppf () = if forced then Fmt.string ppf "; forced=true" in
+        let pp_forced ppf () = if force then Fmt.string ppf "; force=true" in
         l "[%s] merge started { id = %d%a }" (Filename.basename t.root) merge_id
           pp_forced ());
     Stats.incr_nb_merge ();
@@ -708,7 +708,7 @@ struct
                 assert (n = Entry.encoded_size);
                 Some (Entry.decode (Bytes.unsafe_to_string buf) 0)))
 
-  let force_merge ?hook t =
+  let try_merge_aux ?hook ?(force = false) t =
     let t = check_open t in
     let witness =
       Semaphore.with_acquire t.rename_lock (fun () -> get_witness t)
@@ -717,9 +717,24 @@ struct
     | None ->
         Log.debug (fun l -> l "[%s] index is empty" (Filename.basename t.root));
         Thread.return `Completed
-    | Some witness -> merge' ~forced:true ?hook ~witness t
+    | Some witness -> (
+        match t.log with
+        | None ->
+            Log.debug (fun l ->
+                l "[%s] log is empty" (Filename.basename t.root));
+            Thread.return `Completed
+        | Some log ->
+            if
+              force
+              || Int64.compare (IO.offset log.io)
+                   (Int64.of_int t.config.log_size)
+                 > 0
+            then merge' ~force ?hook ~witness t
+            else Thread.return `Completed)
 
-  let merge t = ignore (force_merge ?hook:None t : _ async)
+  let merge t = ignore (try_merge_aux ?hook:None ~force:true t : _ async)
+
+  let try_merge t = ignore (try_merge_aux ?hook:None ~force:false t : _ async)
 
   (** [t.merge_lock] is used to detect an ongoing merge. Other operations can
       take this lock, but as they are not async, we consider this to be a good

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -182,6 +182,10 @@ module type S = sig
       merge is complete. It then launches a merge (which runs concurrently) and
       returns. *)
 
+  val try_merge : t -> unit
+  (** [try_merge] is like {!merge} but is a no-op if the number of entries in
+      the write-ahead log is smaller than [log_size]. *)
+
   (** Offline [fsck]-like utility for checking the integrity of Index stores
       built using this module. *)
   module Checks : sig
@@ -233,8 +237,12 @@ module type Private = sig
 
   val clear' : hook:[ `Abort_signalled ] hook -> t -> unit
 
-  val force_merge : ?hook:merge_stages hook -> t -> merge_result async
-  (** [force_merge t] forces a merge for [t]. *)
+  val try_merge_aux :
+    ?hook:merge_stages hook -> ?force:bool -> t -> merge_result async
+  (** [try_merge_aux t] tries to merge [t]. If [force] is false (the default), a
+      merge is performed only if there is more entries in the write-ahead log
+      than the configured limits. If [force] is set, the merge is performed no
+      matter what. *)
 
   val await : 'a async -> ('a, [ `Async_exn of exn ]) result
   (** Wait for an asynchronous computation to finish. *)

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -163,7 +163,7 @@ struct
       Hashtbl.replace tbl k v
     done;
     Index.flush rw;
-    Index.force_merge rw |> Index.await |> check_completed;
+    Index.try_merge_aux ~force:true rw |> Index.await |> check_completed;
     f := flush_callback (* Enable [flush_callback] *);
     let clone ?(fresh = false) ~readonly () =
       let t =


### PR DESCRIPTION
[try_merge] will not trigger if the log limits have not been reach.
Use [try_merge ~force:true] to match the previous behavior.