### PR TITLE
index: use 63-bit integers in the fanout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Changed
+
+- Optimised the in-memory representation of index handles, resulting in a
+  significant reduction in memory use. (#273)
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/index.opam
+++ b/index.opam
@@ -34,6 +34,7 @@ depends: [
   "alcotest" {with-test}
   "crowbar"  {with-test & >= "0.2"}
   "re"       {with-test}
+  "optint"
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""
@@ -46,3 +47,7 @@ run-time can share a common singleton instance.
 
 Index supports multiple-reader/single-writer access. Concurrent access
 is safely managed using lock files."""
+
+pin-depends: [
+  [ "optint.dev" "git+https://github.com/CraigFe/optint#9426474b65180c4086074f3c36ef628882a4c689" ]
+]

--- a/index.opam
+++ b/index.opam
@@ -21,6 +21,7 @@ build: [
 depends: [
   "ocaml"   {>= "4.08.0"}
   "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.0.5"}
   "repr"    {>= "0.2.0"}
   "ppx_repr"
   "fmt"
@@ -34,7 +35,6 @@ depends: [
   "alcotest" {with-test}
   "crowbar"  {with-test & >= "0.2"}
   "re"       {with-test}
-  "optint"
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""
@@ -47,7 +47,3 @@ run-time can share a common singleton instance.
 
 Index supports multiple-reader/single-writer access. Concurrent access
 is safely managed using lock files."""
-
-pin-depends: [
-  [ "optint.dev" "git+https://github.com/CraigFe/optint#9426474b65180c4086074f3c36ef628882a4c689" ]
-]

--- a/src/dune
+++ b/src/dune
@@ -2,6 +2,6 @@
  (public_name index)
  (name index)
  (libraries logs fmt stdlib-shims mtime mtime.clock.os cmdliner logs.fmt
-   logs.cli fmt.cli fmt.tty jsonm progress progress.unix repr ppx_repr)
+   logs.cli fmt.cli fmt.tty jsonm progress progress.unix repr ppx_repr optint)
  (preprocess
   (pps ppx_repr)))

--- a/src/fan.mli
+++ b/src/fan.mli
@@ -27,10 +27,10 @@ val v : hash_size:int -> entry_size:int -> int -> [ `Write ] t
 val nb_fans : 'a t -> int
 (** [nb_fans t] is the number of fans in [t]. *)
 
-val search : [ `Read ] t -> int -> int64 * int64
+val search : [ `Read ] t -> int -> Int63.t * Int63.t
 (** [search t hash] is the interval of offsets containing [hash], if present. *)
 
-val update : [ `Write ] t -> int -> int64 -> unit
+val update : [ `Write ] t -> int -> Int63.t -> unit
 (** [update t hash off] updates [t] so that [hash] is registered to be at offset
     [off]. *)
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -436,7 +436,9 @@ struct
     let hashed_key = K.hash key in
     let low_bytes, high_bytes = Fan.search index.fan_out hashed_key in
     let low, high =
-      Int64.(div low_bytes entry_sizeL, div high_bytes entry_sizeL)
+      Int64.
+        ( div (Int63.to_int64 low_bytes) entry_sizeL,
+          div (Int63.to_int64 high_bytes) entry_sizeL )
     in
     Search.interpolation_search (IOArray.v index.io) key ~low ~high
 
@@ -478,11 +480,11 @@ struct
     match find_instance t key with _ -> true | exception Not_found -> false
 
   let append_buf_fanout fan_out hash buf_str dst_io =
-    Fan.update fan_out hash (IO.offset dst_io);
+    Fan.update fan_out hash (Int63.of_int64 (IO.offset dst_io));
     IO.append dst_io buf_str
 
   let append_entry_fanout fan_out entry dst_io =
-    Fan.update fan_out entry.Entry.key_hash (IO.offset dst_io);
+    Fan.update fan_out entry.Entry.key_hash (Int63.of_int64 (IO.offset dst_io));
     Entry.encode entry (IO.append dst_io)
 
   let rec merge_from_log fan_out log log_i hash_e dst_io =

--- a/test/fuzz/fan/dune
+++ b/test/fuzz/fan/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
- (libraries crowbar index))
+ (libraries crowbar index optint))
 
 (alias
  (name runtest)

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -5,7 +5,7 @@ let hash_size = 30
 
 let entry_size = 56
 
-let entry_sizeL = Int64.of_int entry_size
+let entry_sizeL = Int63.of_int entry_size
 
 let int_bound = 100_000_000
 
@@ -23,9 +23,9 @@ let empty_fan = map [ empty_fan_with_size ] fst
 let update_list =
   let rec loop off acc = function
     | [] -> List.rev acc
-    | hash :: t -> loop (Int64.add off entry_sizeL) ((hash, off) :: acc) t
+    | hash :: t -> loop (Int63.add off entry_sizeL) ((hash, off) :: acc) t
   in
-  map [ hash_list ] (loop 0L [])
+  map [ hash_list ] (loop Int63.zero [])
 
 let fan_with_updates =
   map [ empty_fan; update_list ] (fun fan l ->
@@ -50,8 +50,8 @@ let check_updates (fan, updates) =
     (fun (hash, off) ->
       let low, high = Fan.search fan hash in
       if off < low || high < off then
-        failf "hash %d was added at off %Ld, but got low=%Ld, high=%Ld" hash off
-          low high)
+        failf "hash %d was added at off %a, but got low=%a, high=%a" hash
+          Int63.pp off Int63.pp low Int63.pp high)
     updates
 
 let check_fan_size (fan, size) =


### PR DESCRIPTION
On 64-bit systems, this should reduce the memory usage of the fan-out by a factor of 4.