### PR TITLE
Use 63-bit integers as file offsets

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -49,5 +49,5 @@ Index supports multiple-reader/single-writer access. Concurrent access
 is safely managed using lock files."""
 
 pin-depends: [
-  [ "optint.dev" "git+https://github.com/CraigFe/optint#2bd60df1cac71e51e6b0c58036fdd63a9b3c9516" ]
+  [ "optint.dev" "git+https://github.com/mirage/optint#b1ad9aa3f3412fb0ec93d05b1cf519a01ff475cd" ]
 ]

--- a/index.opam
+++ b/index.opam
@@ -47,3 +47,7 @@ run-time can share a common singleton instance.
 
 Index supports multiple-reader/single-writer access. Concurrent access
 is safely managed using lock files."""
+
+pin-depends: [
+  [ "optint.dev" "git+https://github.com/CraigFe/optint#2bd60df1cac71e51e6b0c58036fdd63a9b3c9516" ]
+]

--- a/src/checks.ml
+++ b/src/checks.ml
@@ -1,3 +1,4 @@
+module Int63 = Optint.Int63
 include Checks_intf
 
 module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct

--- a/src/fan.ml
+++ b/src/fan.ml
@@ -15,6 +15,8 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
+module Int63 = Optint.Int63
+
 type 'a t = { fans : Int63.t array; mask : int; shift : int }
 
 let equal t t' =

--- a/src/fan.mli
+++ b/src/fan.mli
@@ -15,6 +15,8 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
+module Int63 = Optint.Int63
+
 type 'a t
 
 val equal : 'a t -> 'a t -> bool

--- a/src/index.ml
+++ b/src/index.ml
@@ -16,6 +16,7 @@ The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
 include Index_intf
+module Int63 = Optint.Int63
 module Stats = Stats
 module Cache = Cache
 module Checks = Checks

--- a/src/io_array.ml
+++ b/src/io_array.ml
@@ -15,6 +15,8 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
+module Int63 = Optint.Int63
+
 module type ELT = sig
   type t
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -5,20 +5,20 @@ module type S = sig
     ?flush_callback:(unit -> unit) ->
     readonly:bool ->
     fresh:bool ->
-    generation:int64 ->
-    fan_size:int64 ->
+    generation:Int63.t ->
+    fan_size:Int63.t ->
     string ->
     t
 
-  val offset : t -> int64
+  val offset : t -> Int63.t
 
-  val read : t -> off:int64 -> len:int -> bytes -> int
+  val read : t -> off:Int63.t -> len:int -> bytes -> int
 
-  val clear : generation:int64 -> t -> unit
+  val clear : generation:Int63.t -> t -> unit
 
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
 
-  val get_generation : t -> int64
+  val get_generation : t -> Int63.t
 
   val set_fanout : t -> string -> unit
 
@@ -42,7 +42,7 @@ module type S = sig
   end
 
   module Header : sig
-    type header = { offset : int64; generation : int64 }
+    type header = { offset : Int63.t; generation : Int63.t }
 
     val set : t -> header -> unit
 
@@ -68,10 +68,10 @@ module type Io = sig
     include S with type t = S.t
 
     val iter :
-      page_size:int64 ->
-      ?min:int64 ->
-      ?max:int64 ->
-      (off:int64 -> buf:string -> buf_off:int -> int) ->
+      page_size:Int63.t ->
+      ?min:Int63.t ->
+      ?max:Int63.t ->
+      (off:Int63.t -> buf:string -> buf_off:int -> int) ->
       t ->
       unit
   end

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -1,3 +1,5 @@
+module Int63 = Optint.Int63
+
 module type S = sig
   type t
 

--- a/src/search_intf.ml
+++ b/src/search_intf.ml
@@ -20,11 +20,11 @@ module type ARRAY = sig
 
   type elt
 
-  val get : t -> int64 -> elt
+  val get : t -> Int63.t -> elt
 
-  val length : t -> int64
+  val length : t -> Int63.t
 
-  val pre_fetch : t -> low:int64 -> high:int64 -> unit
+  val pre_fetch : t -> low:Int63.t -> high:Int63.t -> unit
 end
 
 module type ENTRY = sig
@@ -56,7 +56,7 @@ module type METRIC = sig
 
   val of_key : Entry.Key.t -> t
 
-  val linear_interpolate : low:int64 * t -> high:int64 * t -> t -> int64
+  val linear_interpolate : low:Int63.t * t -> high:Int63.t * t -> t -> Int63.t
 end
 
 module type S = sig
@@ -65,7 +65,7 @@ module type S = sig
   module Array : ARRAY with type elt = Entry.t
 
   val interpolation_search :
-    Array.t -> Entry.Key.t -> low:int64 -> high:int64 -> Entry.Value.t
+    Array.t -> Entry.Key.t -> low:Int63.t -> high:Int63.t -> Entry.Value.t
 end
 
 module type Search = sig

--- a/src/search_intf.ml
+++ b/src/search_intf.ml
@@ -15,6 +15,8 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
+module Int63 = Optint.Int63
+
 module type ARRAY = sig
   type t
 

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -5,4 +5,4 @@
  (public_name index.unix)
  (name index_unix)
  (libraries fmt index logs logs.threaded threads.posix unix semaphore-compat
-   mtime mtime.clock.os))
+   mtime mtime.clock.os optint))

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -15,6 +15,8 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software. *)
 
+module Int63 = Optint.Int63
+
 let src = Logs.Src.create "index_unix" ~doc:"Index_unix"
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/unix/pread.c
+++ b/src/unix/pread.c
@@ -4,7 +4,26 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
-CAMLprim value caml_index_pread
+CAMLprim value caml_index_pread_int
+(value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
+{
+  CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);
+
+  ssize_t ret;
+  size_t fd = Int_val(v_fd);
+  size_t fd_off = Int_val(v_fd_off);
+  size_t buf_off = Long_val(v_buf_off);
+  size_t len = Long_val(v_len);
+
+  size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
+  ret = pread(fd, &Byte(v_buf, buf_off), numbytes, fd_off);
+
+  if (ret == -1) uerror("read", Nothing);
+
+  CAMLreturn(Val_long(ret));
+}
+
+CAMLprim value caml_index_pread_int64
 (value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
 {
   CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);

--- a/src/unix/pwrite.c
+++ b/src/unix/pwrite.c
@@ -4,7 +4,26 @@
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
 
-CAMLprim value caml_index_pwrite
+CAMLprim value caml_index_pwrite_int
+(value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
+{
+  CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);
+
+  ssize_t ret;
+  size_t fd = Int_val(v_fd);
+  size_t fd_off = Int_val(v_fd_off);
+  size_t buf_off = Long_val(v_buf_off);
+  size_t len = Long_val(v_len);
+
+  size_t numbytes = (len > UNIX_BUFFER_SIZE) ? UNIX_BUFFER_SIZE : len;
+  ret = pwrite(fd, &Byte(v_buf, buf_off), numbytes, fd_off);
+
+  if (ret == -1) uerror("write", Nothing);
+
+  CAMLreturn(Val_long(ret));
+}
+
+CAMLprim value caml_index_pwrite_int64
 (value v_fd, value v_fd_off, value v_buf, value v_buf_off, value v_len)
 {
   CAMLparam5(v_fd, v_fd_off, v_buf, v_buf_off, v_len);

--- a/src/unix/raw.ml
+++ b/src/unix/raw.ml
@@ -1,26 +1,6 @@
-let ( ++ ) = Int64.add
+let ( ++ ) = Int63.add
 
 module Stats = Index.Stats
-
-external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64u"
-
-external get_64 : string -> int -> int64 = "%caml_string_get64"
-
-external swap64 : int64 -> int64 = "%bswap_int64"
-
-let encode_int64 i =
-  let set_uint64 s off v =
-    if not Sys.big_endian then set_64 s off (swap64 v) else set_64 s off v
-  in
-  let b = Bytes.create 8 in
-  set_uint64 b 0 i;
-  Bytes.unsafe_to_string b
-
-let decode_int64 buf =
-  let get_uint64 s off =
-    if not Sys.big_endian then swap64 (get_64 s off) else get_64 s off
-  in
-  get_uint64 buf 0
 
 type t = { fd : Unix.file_descr } [@@unboxed]
 
@@ -32,7 +12,7 @@ let really_write fd fd_offset buffer =
     if w = 0 || w = length then ()
     else
       (aux [@tailcall])
-        (fd_offset ++ Int64.of_int w)
+        (fd_offset ++ Int63.of_int w)
         (buffer_offset + w) (length - w)
   in
   aux fd_offset 0 (Bytes.length buffer)
@@ -44,7 +24,7 @@ let really_read fd fd_offset length buffer =
     else if r = length then buffer_offset + r
     else
       (aux [@tailcall])
-        (fd_offset ++ Int64.of_int r)
+        (fd_offset ++ Int63.of_int r)
         (buffer_offset + r) (length - r)
   in
   aux fd_offset 0 length
@@ -65,6 +45,13 @@ let unsafe_read t ~off ~len buf =
   Stats.add_read n;
   n
 
+let encode_int63 n =
+  let buf = Bytes.create Int63.encoded_size in
+  Int63.encode buf ~off:0 n;
+  Bytes.unsafe_to_string buf
+
+let decode_int63 buf = Int63.decode ~off:0 buf
+
 let assert_read ~len n =
   assert (
     if Int.equal n len then true
@@ -75,69 +62,73 @@ let assert_read ~len n =
   [@@inline always]
 
 module Offset = struct
-  let set t n =
-    let buf = encode_int64 n in
-    unsafe_write t ~off:0L buf
+  let off = Int63.zero
+
+  let set t n = unsafe_write t ~off (encode_int63 n)
 
   let get t =
     let len = 8 in
     let buf = Bytes.create len in
-    let n = unsafe_read t ~off:0L ~len buf in
+    let n = unsafe_read t ~off ~len buf in
     assert_read ~len n;
-    decode_int64 (Bytes.unsafe_to_string buf)
+    decode_int63 (Bytes.unsafe_to_string buf)
 end
 
 module Version = struct
+  let off = Int63.of_int 8
+
   let get t =
     let len = 8 in
     let buf = Bytes.create len in
-    let n = unsafe_read t ~off:8L ~len buf in
+    let n = unsafe_read t ~off ~len buf in
     assert_read ~len n;
     Bytes.unsafe_to_string buf
 
-  let set t v = unsafe_write t ~off:8L v
+  let set t v = unsafe_write t ~off v
 end
 
 module Generation = struct
+  let off = Int63.of_int 16
+
   let get t =
     let len = 8 in
     let buf = Bytes.create len in
-    let n = unsafe_read t ~off:16L ~len buf in
+    let n = unsafe_read t ~off ~len buf in
     assert_read ~len n;
-    decode_int64 (Bytes.unsafe_to_string buf)
+    decode_int63 (Bytes.unsafe_to_string buf)
 
-  let set t gen =
-    let buf = encode_int64 gen in
-    unsafe_write t ~off:16L buf
+  let set t gen = unsafe_write t ~off (encode_int63 gen)
 end
 
 module Fan = struct
+  let off = Int63.of_int 24
+
   let set t buf =
-    let size = encode_int64 (Int64.of_int (String.length buf)) in
-    unsafe_write t ~off:24L size;
-    if buf <> "" then unsafe_write t ~off:(24L ++ 8L) buf
+    let size = encode_int63 (Int63.of_int (String.length buf)) in
+    unsafe_write t ~off size;
+    if buf <> "" then unsafe_write t ~off:(off ++ Int63.of_int 8) buf
 
   let get_size t =
     let len = 8 in
     let size_buf = Bytes.create len in
-    let n = unsafe_read t ~off:24L ~len size_buf in
+    let n = unsafe_read t ~off ~len size_buf in
     assert_read ~len n;
-    decode_int64 (Bytes.unsafe_to_string size_buf)
+    decode_int63 (Bytes.unsafe_to_string size_buf)
 
   let set_size t size =
-    let buf = encode_int64 size in
-    unsafe_write t ~off:24L buf
+    let buf = encode_int63 size in
+    unsafe_write t ~off buf
 
   let get t =
-    let size = Int64.to_int (get_size t) in
+    let size = Int63.to_int (get_size t) in
     let buf = Bytes.create size in
-    let n = unsafe_read t ~off:(24L ++ 8L) ~len:size buf in
+    let n = unsafe_read t ~off:(off ++ Int63.of_int 8) ~len:size buf in
     assert_read ~len:size n;
     Bytes.unsafe_to_string buf
 end
 
 module Header = struct
-  type t = { offset : int64; version : string; generation : int64 }
+  type t = { offset : Int63.t; version : string; generation : Int63.t }
 
   (** NOTE: These functions must be equivalent to calling the above [set] /
       [get] functions individually. *)
@@ -151,18 +142,18 @@ module Header = struct
 
   let get t =
     let header = Bytes.create total_header_length in
-    let n = unsafe_read t ~off:0L ~len:total_header_length header in
+    let n = unsafe_read t ~off:Int63.zero ~len:total_header_length header in
     assert_read ~len:total_header_length n;
-    let offset = read_word header 0 |> decode_int64 in
+    let offset = read_word header 0 |> decode_int63 in
     let version = read_word header 8 in
-    let generation = read_word header 16 |> decode_int64 in
+    let generation = read_word header 16 |> decode_int63 in
     { offset; version; generation }
 
   let set t { offset; version; generation } =
     assert (String.length version = 8);
     let b = Bytes.create total_header_length in
-    Bytes.blit_string (encode_int64 offset) 0 b 0 8;
+    Bytes.blit_string (encode_int63 offset) 0 b 0 8;
     Bytes.blit_string version 0 b 8 8;
-    Bytes.blit_string (encode_int64 generation) 0 b 16 8;
-    unsafe_write t ~off:0L (Bytes.unsafe_to_string b)
+    Bytes.blit_string (encode_int63 generation) 0 b 16 8;
+    unsafe_write t ~off:Int63.zero (Bytes.unsafe_to_string b)
 end

--- a/src/unix/raw.ml
+++ b/src/unix/raw.ml
@@ -1,6 +1,7 @@
-let ( ++ ) = Int63.add
-
+module Int63 = Optint.Int63
 module Stats = Index.Stats
+
+let ( ++ ) = Int63.add
 
 type t = { fd : Unix.file_descr } [@@unboxed]
 

--- a/src/unix/raw.mli
+++ b/src/unix/raw.mli
@@ -14,9 +14,9 @@ type t
 val v : Unix.file_descr -> t
 (** Construct a [raw] value from a file descriptor. *)
 
-val unsafe_write : t -> off:int64 -> string -> unit
+val unsafe_write : t -> off:Int63.t -> string -> unit
 
-val unsafe_read : t -> off:int64 -> len:int -> bytes -> int
+val unsafe_read : t -> off:Int63.t -> len:int -> bytes -> int
 
 val fsync : t -> unit
 
@@ -31,15 +31,15 @@ module Version : sig
 end
 
 module Offset : sig
-  val get : t -> int64
+  val get : t -> Int63.t
 
-  val set : t -> int64 -> unit
+  val set : t -> Int63.t -> unit
 end
 
 module Generation : sig
-  val get : t -> int64
+  val get : t -> Int63.t
 
-  val set : t -> int64 -> unit
+  val set : t -> Int63.t -> unit
 end
 
 module Fan : sig
@@ -47,18 +47,18 @@ module Fan : sig
 
   val set : t -> string -> unit
 
-  val get_size : t -> int64
+  val get_size : t -> Int63.t
 
-  val set_size : t -> int64 -> unit
+  val set_size : t -> Int63.t -> unit
 end
 
 module Header : sig
   type raw
 
   type t = {
-    offset : int64;  (** The length of the file containing valid data *)
+    offset : Int63.t;  (** The length of the file containing valid data *)
     version : string;  (** Format version *)
-    generation : int64;  (** Generation number *)
+    generation : Int63.t;  (** Generation number *)
   }
 
   val get : raw -> t

--- a/src/unix/raw.mli
+++ b/src/unix/raw.mli
@@ -1,3 +1,5 @@
+module Int63 = Optint.Int63
+
 (** [Raw] wraps a file-descriptor with an file-format used internally by Index.
     The format contains the following header fields:
 

--- a/src/unix/syscalls.ml
+++ b/src/unix/syscalls.ml
@@ -1,11 +1,31 @@
-external pread : Unix.file_descr -> int64 -> bytes -> int -> int -> int
-  = "caml_index_pread"
+external pread_int : Unix.file_descr -> int -> bytes -> int -> int -> int
+  = "caml_index_pread_int"
 
-let pread ~fd ~fd_offset ~buffer ~buffer_offset ~length =
-  pread fd fd_offset buffer buffer_offset length
+external pread_int64 : Unix.file_descr -> int64 -> bytes -> int -> int -> int
+  = "caml_index_pread_int64"
 
-external pwrite : Unix.file_descr -> int64 -> bytes -> int -> int -> int
-  = "caml_index_pwrite"
+let pread : fd:_ -> fd_offset:Int63.t -> _ =
+  match Int63.observe with
+  | Int Refl ->
+      fun ~fd ~fd_offset ~buffer ~buffer_offset ~length ->
+        pread_int fd fd_offset buffer buffer_offset length
+  | Int64 cast ->
+      fun ~fd ~fd_offset ~buffer ~buffer_offset ~length ->
+        pread_int64 fd (cast fd_offset) buffer buffer_offset length
+  | _ -> assert false
 
-let pwrite ~fd ~fd_offset ~buffer ~buffer_offset ~length =
-  pwrite fd fd_offset buffer buffer_offset length
+external pwrite_int : Unix.file_descr -> int -> bytes -> int -> int -> int
+  = "caml_index_pwrite_int"
+
+external pwrite_int64 : Unix.file_descr -> int64 -> bytes -> int -> int -> int
+  = "caml_index_pwrite_int64"
+
+let pwrite : fd:_ -> fd_offset:Int63.t -> _ =
+  match Int63.observe with
+  | Int Refl ->
+      fun ~fd ~fd_offset ~buffer ~buffer_offset ~length ->
+        pwrite_int fd fd_offset buffer buffer_offset length
+  | Int64 cast ->
+      fun ~fd ~fd_offset ~buffer ~buffer_offset ~length ->
+        pwrite_int64 fd (cast fd_offset) buffer buffer_offset length
+  | _ -> assert false

--- a/src/unix/syscalls.mli
+++ b/src/unix/syscalls.mli
@@ -1,6 +1,6 @@
 val pread :
   fd:Unix.file_descr ->
-  fd_offset:int64 ->
+  fd_offset:Int63.t ->
   buffer:bytes ->
   buffer_offset:int ->
   length:int ->
@@ -11,7 +11,7 @@ val pread :
 
 val pwrite :
   fd:Unix.file_descr ->
-  fd_offset:int64 ->
+  fd_offset:Int63.t ->
   buffer:bytes ->
   buffer_offset:int ->
   length:int ->

--- a/src/unix/syscalls.mli
+++ b/src/unix/syscalls.mli
@@ -1,3 +1,5 @@
+module Int63 = Optint.Int63
+
 val pread :
   fd:Unix.file_descr ->
   fd_offset:Int63.t ->

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
  (name main)
  (package index)
- (libraries index alcotest))
+ (libraries index alcotest optint))

--- a/test/fuzz/fan/main.ml
+++ b/test/fuzz/fan/main.ml
@@ -1,5 +1,6 @@
 open Crowbar
 module Fan = Index.Private.Fan
+module Int63 = Optint.Int63
 
 let hash_size = 30
 

--- a/test/search.ml
+++ b/test/search.ml
@@ -21,9 +21,9 @@ module EltArray = struct
 
   type elt = Entry.t
 
-  let get t i = t.(Int64.to_int i)
+  let get t i = t.(Int63.to_int i)
 
-  let length t = Array.length t |> Int64.of_int
+  let length t = Array.length t |> Int63.of_int
 
   let pre_fetch _ ~low:_ ~high:_ = ()
 end
@@ -44,14 +44,14 @@ module Metric_key = struct
     let low_in = float_of_int low_in in
     let high_in = float_of_int high_in in
     let target_in = float_of_int m in
-    let low_out = Int64.to_float low_out in
-    let high_out = Int64.to_float high_out in
+    let low_out = Int63.to_float low_out in
+    let high_out = Int63.to_float high_out in
     (* Fractional position of [target_in] along the line from [low_in] to [high_in] *)
     let proportion = (target_in -. low_in) /. (high_in -. low_in) in
     (* Convert fractional position to position in output space *)
     let position = low_out +. (proportion *. (high_out -. low_out)) in
     let rounded = ceil (position -. 0.5) +. 0.5 in
-    Int64.of_float rounded
+    Int63.of_float rounded
 end
 
 module Search = Index.Private.Search.Make (Entry) (EltArray) (Metric_key)
@@ -62,8 +62,8 @@ let interpolation_unique () =
   Array.iter
     (fun (i, v) ->
       Search.interpolation_search array i
-        ~low:Int64.(zero)
-        ~high:Int64.(pred length)
+        ~low:Int63.(zero)
+        ~high:Int63.(pred length)
       |> Alcotest.(check string) "" v)
     array
 
@@ -80,9 +80,11 @@ module Metric_constant = struct
   let of_key _ = ()
 
   let linear_interpolate ~low:(low_out, _) ~high:(high_out, _) _ =
-    let ( + ), ( - ) = Int64.(add, sub) in
+    let ( + ), ( - ) = Int63.(add, sub) in
     (* Any value in the range [low_out, high_out] is valid *)
-    low_out + Random.int64 (high_out - low_out) + 1L
+    low_out
+    + Int63.of_int64 (Random.int64 (Int63.to_int64 (high_out - low_out)))
+    + Int63.one
 end
 
 module Search_constant =
@@ -93,8 +95,8 @@ let interpolation_constant_metric () =
   let length = EltArray.length array in
   Array.iter
     (fun (i, v) ->
-      Search_constant.interpolation_search array i ~low:0L
-        ~high:Int64.(pred length)
+      Search_constant.interpolation_search array i ~low:Int63.zero
+        ~high:Int63.(pred length)
       |> Alcotest.(check string) "" v)
     array
 

--- a/test/search.ml
+++ b/test/search.ml
@@ -1,3 +1,5 @@
+module Int63 = Optint.Int63
+
 module Entry = struct
   module Key = struct
     type t = int

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -2,4 +2,4 @@
  (names main force_merge io_array)
  (package index)
  (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims
-   threads.posix repr semaphore-compat))
+   threads.posix repr semaphore-compat optint))

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -29,7 +29,8 @@ module IOArray = Index.Private.Io_array.Make (IO) (Entry)
 let entry = Alcotest.(pair string string)
 
 let fresh_io name =
-  IO.v ~readonly:false ~fresh:true ~generation:0L ~fan_size:0L (root // name)
+  IO.v ~readonly:false ~fresh:true ~generation:Int63.zero ~fan_size:Int63.zero
+    (root // name)
 
 (* Append a random sequence of [size] keys to an IO instance and return
    a pair of an IOArray and an equivalent in-memory array. *)
@@ -53,7 +54,7 @@ let read_sequential () =
   let mem_arr, io_arr = populate_random ~size io in
   for i = 0 to size - 1 do
     let expected = mem_arr.(i) in
-    let actual = IOArray.get io_arr (Int64.of_int i) in
+    let actual = IOArray.get io_arr (Int63.of_int i) in
     Alcotest.(check entry)
       (Fmt.strf "Inserted key at index %i is accessible" i)
       expected actual
@@ -63,12 +64,12 @@ let read_sequential_prefetch () =
   let size = 1000 in
   let io = fresh_io "read_sequential_prefetch" in
   let mem_arr, io_arr = populate_random ~size io in
-  IOArray.pre_fetch io_arr ~low:0L ~high:999L;
+  IOArray.pre_fetch io_arr ~low:Int63.zero ~high:(Int63.of_int 999);
 
   (* Read the arrays backwards *)
   for i = size - 1 to 0 do
     let expected = mem_arr.(i) in
-    let actual = IOArray.get io_arr (Int64.of_int i) in
+    let actual = IOArray.get io_arr (Int63.of_int i) in
     Alcotest.(check entry)
       (Fmt.strf "Inserted key at index %i is accessible" i)
       expected actual

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -1,3 +1,4 @@
+module Int63 = Optint.Int63
 module IO = Index_unix.Private.IO
 
 let ( // ) = Filename.concat


### PR DESCRIPTION
Fix https://github.com/mirage/index/issues/285.

Currently using an unreleased feature in `optint` to allow observing the type equality without a coercion. Very slightly faster than using the (identity) cast, which doesn't seem to be inlined w/o Flambda 2.