### PR TITLE
Remove files on disk on `clear`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 - Benches are now executed 3 times and a new option `nb-exec` has been added (#292)
 
+- `clear` removes the files on disks and opens new ones containing only the
+  header. (#288)
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/src/index.ml
+++ b/src/index.ml
@@ -990,6 +990,7 @@ module Private = struct
   module Io_array = Io_array
   module Search = Search
   module Data = Data
+  module Layout = Layout
 
   module Hook = struct
     type 'a t = 'a -> unit

--- a/src/index.ml
+++ b/src/index.ml
@@ -164,7 +164,8 @@ struct
         t.pending_cancel <- false;
         t.generation <- Int63.succ t.generation;
         let log = Option.get t.log in
-        IO.clear ~generation:t.generation log.io;
+        let hook () = hook `IO_clear in
+        IO.clear ~generation:t.generation ~hook log.io;
         Tbl.clear log.mem;
         Option.iter
           (fun l ->

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -365,6 +365,7 @@ module type Index = sig
     module Io_array = Io_array
     module Fan = Fan
     module Data = Data
+    module Layout = Layout
 
     module type S = Private with type 'a hook := 'a Hook.t
 

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -237,7 +237,7 @@ module type Private = sig
       concurrent merge operations, but {i before} blocking on those
       cancellations having completed. *)
 
-  val clear' : hook:[ `Abort_signalled ] hook -> t -> unit
+  val clear' : hook:[ `Abort_signalled | `IO_clear ] hook -> t -> unit
 
   val try_merge_aux :
     ?hook:merge_stages hook -> ?force:bool -> t -> merge_result async

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -15,7 +15,6 @@ module type S = sig
   val offset : t -> int63
   val read : t -> off:int63 -> len:int -> bytes -> int
   val clear : generation:int63 -> ?hook:(unit -> unit) -> t -> unit
-
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
   val get_generation : t -> int63
   val set_fanout : t -> string -> unit

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -14,7 +14,8 @@ module type S = sig
   val v_readonly : string -> (t, [ `No_file_on_disk ]) result
   val offset : t -> int63
   val read : t -> off:int63 -> len:int -> bytes -> int
-  val clear : generation:int63 -> t -> unit
+  val clear : generation:int63 -> ?hook:(unit -> unit) -> t -> unit
+
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
   val get_generation : t -> int63
   val set_fanout : t -> string -> unit

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -152,13 +152,14 @@ module IO : Index.IO = struct
     Raw.Fan.set raw "";
     raw
 
-  let clear ~generation t =
+  let clear ~generation ?(hook = fun () -> ()) t =
     t.offset <- Int63.zero;
     t.flushed <- t.header;
     Buffer.clear t.buf;
     (* the generation is updated before calling clear. *)
     Header.set t { offset = t.offset; generation };
     Raw.close t.raw;
+    hook ();
     (* delete the file. *)
     Unix.unlink t.file;
     (* and re-open a fresh instance *)

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -156,17 +156,26 @@ module IO : Index.IO = struct
     t.offset <- Int63.zero;
     t.flushed <- t.header;
     Buffer.clear t.buf;
-    (* the generation is updated before calling clear. *)
-    Header.set t { offset = t.offset; generation };
+    let tmp = t.file ^ "_tmp" in
     Raw.close t.raw;
+    (* Rename file into a temporary file. This allows a fresh file to be
+       created, before writing the new generation in the temporary file. *)
+    Unix.rename t.file tmp;
     hook ();
-    (* delete the file. *)
-    Unix.unlink t.file;
-    (* and re-open a fresh instance *)
+    (* Open a fresh file. *)
     t.raw <-
       raw ~version:current_version ~generation ~offset:Int63.zero
         ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
-        t.file
+        t.file;
+    (* Set new generation in the temporary file. *)
+    let tmp_fd =
+      raw ~version:current_version ~generation ~offset:Int63.zero
+        ~flags:Unix.[ O_RDWR; O_CLOEXEC ]
+        tmp
+    in
+    (* Close and remove temporary file. *)
+    Raw.close tmp_fd;
+    Unix.unlink tmp
 
   let () = assert (String.length current_version = 8)
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -144,13 +144,28 @@ module IO : Index.IO = struct
     in
     (aux [@tailcall]) dirname (fun () -> ())
 
+  let raw ~flags ~version ~offset ~generation file =
+    let x = Unix.openfile file flags 0o644 in
+    let raw = Raw.v x in
+    let header = { Raw.Header.offset; version; generation } in
+    Raw.Header.set raw header;
+    Raw.Fan.set raw "";
+    raw
+
   let clear ~generation t =
     t.offset <- Int63.zero;
     t.flushed <- t.header;
-    Header.set t { offset = t.offset; generation };
-    Raw.Fan.set t.raw "";
     Buffer.clear t.buf;
-    Raw.fsync t.raw
+    (* the generation is updated before calling clear. *)
+    Header.set t { offset = t.offset; generation };
+    Raw.close t.raw;
+    (* delete the file. *)
+    Unix.unlink t.file;
+    (* and re-open a fresh instance *)
+    t.raw <-
+      raw ~version:current_version ~generation ~offset:Int63.zero
+        ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
+        t.file
 
   let () = assert (String.length current_version = 8)
 

--- a/test/cli/stat.t/run.t
+++ b/test/cli/stat.t/run.t
@@ -24,7 +24,7 @@ Running `stat` on an index after 10 merges:
         "fanout_size": "128.0 B"
       },
       "log": {
-        "size": "3.9 KiB",
+        "size": "3.6 KiB",
         "offset": 3680,
         "generation": 9,
         "fanout_size": "0.0 B"

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -36,6 +36,12 @@ let () = Random.self_init ()
 let random_char () = char_of_int (33 + Random.int 94)
 let random_string () = String.init String_size.length (fun _i -> random_char ())
 
+module Default = struct
+  let log_size = 4
+
+  let size = 103
+end
+
 module Key = struct
   include Index.Key.String_fixed (String_size)
 
@@ -121,7 +127,7 @@ struct
 
   let ignore (_ : t) = ()
 
-  let empty_index ?(log_size = 4) ?flush_callback ?throttle () =
+  let empty_index ?(log_size = Default.log_size) ?flush_callback ?throttle () =
     let name = fresh_name "empty_index" in
     let cache = Index.empty_cache () in
     let rw =
@@ -138,8 +144,8 @@ struct
     in
     { rw; tbl; clone; close_all = (fun () -> !close_all ()) }
 
-  let full_index ?(size = 103) ?(log_size = 4) ?(flush_callback = fun () -> ())
-      ?throttle () =
+  let full_index ?(size = Default.size) ?(log_size = Default.log_size)
+      ?(flush_callback = fun () -> ()) ?throttle () =
     let f =
       (* Disable [flush_callback] while adding initial entries *)
       ref (fun () -> ())

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -38,7 +38,6 @@ let random_string () = String.init String_size.length (fun _i -> random_char ())
 
 module Default = struct
   let log_size = 4
-
   let size = 103
 end
 

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -5,6 +5,12 @@ val report : unit -> unit
 
 module Log : Logs.LOG
 
+module Default : sig
+  val log_size : int
+
+  val size : int
+end
+
 (** Simple key/value modules with String type and a random constructor *)
 module Key : sig
   include Index.Key.S with type t = string

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -7,7 +7,6 @@ module Log : Logs.LOG
 
 module Default : sig
   val log_size : int
-
   val size : int
 end
 

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -396,7 +396,9 @@ let test_non_blocking_clear () =
     | _ -> ()
   in
   let clear_hook =
-    Hook.v @@ function `Abort_signalled -> Semaphore.release merge
+    Hook.v @@ function
+    | `Abort_signalled -> Semaphore.release merge
+    | `IO_clear -> ()
   in
   add_bindings rw;
   let thread = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
@@ -423,7 +425,9 @@ let test_abort_merge ~abort_merge () =
     | `Before -> ()
   in
   let abort_hook =
-    Hook.v @@ function `Abort_signalled -> Semaphore.release merge
+    Hook.v @@ function
+    | `Abort_signalled -> Semaphore.release merge
+    | `IO_clear -> ()
   in
   let t = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
   Semaphore.acquire merge_started;

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -1,4 +1,5 @@
 module Hook = Index.Private.Hook
+module Layout = Index.Private.Layout
 module Semaphore = Semaphore_compat.Semaphore.Binary
 module I = Index
 open Common
@@ -115,6 +116,29 @@ module Live = struct
     Alcotest.check_raises "Finding absent should raise Not_found" Not_found
       (fun () -> Key.v () |> Index.find rw2 |> ignore_value)
 
+  let files_on_disk_after_clear () =
+    let root = Context.fresh_name "full_index" in
+    let rw = Index.v ~fresh:true ~log_size:Default.log_size root in
+    for _ = 1 to Default.size do
+      let k = Key.v () in
+      let v = Value.v () in
+      Index.replace rw k v
+    done;
+    Index.flush rw;
+    Index.clear rw;
+    Index.close rw;
+    let module I = Index_unix.Private.IO in
+    let test path msg =
+      match I.v_readonly path with
+      | Error `No_file_on_disk -> Alcotest.fail "expected data file"
+      | Ok data ->
+          Alcotest.(check int) msg (I.size data) (I.size_header data);
+          I.close data
+    in
+    test (Layout.log ~root) "size of log file";
+    test (Layout.log_async ~root) "size of log_async file";
+    test (Layout.data ~root) "size of data file"
+
   let duplicate_entries () =
     let* Context.{ rw; _ } = Context.with_empty_index () in
     let k1, v1, v2, v3 = (Key.v (), Value.v (), Value.v (), Value.v ()) in
@@ -141,6 +165,7 @@ module Live = struct
       ("clear and iter", `Quick, iter_after_clear);
       ("clear and find", `Quick, find_after_clear);
       ("open after clear", `Quick, open_after_clear);
+      ("files on disk after clear", `Quick, files_on_disk_after_clear);
       ("duplicate entries", `Quick, duplicate_entries);
     ]
 end

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -514,6 +514,39 @@ module Readonly = struct
     Index.check_binding ro k2 v2;
     Index.check_binding ro k3 v3
 
+  let readonly_sync_and_merge_clear () =
+    let* Context.{ clone; rw; _ } = Context.with_empty_index () in
+    let ro = clone ~readonly:true () in
+    let merge = Semaphore.make false and sync = Semaphore.make false in
+    let merge_hook =
+      I.Private.Hook.v @@ function
+      | `Before ->
+          Semaphore.release sync;
+          Semaphore.acquire merge
+      | `After_clear -> Semaphore.release sync
+      | _ -> ()
+    in
+    let sync_hook =
+      I.Private.Hook.v @@ function
+      | `After_offset_read ->
+          Semaphore.release merge;
+          Semaphore.acquire sync
+      | _ -> ()
+    in
+    let gen i = (String.make Key.encoded_size i, Value.v ()) in
+    let k1, v1 = gen '1' in
+    let k2, v2 = gen '2' in
+
+    Index.replace rw k1 v1;
+    Index.flush rw;
+    let thread = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
+    Index.replace rw k2 v2;
+    Semaphore.acquire sync;
+    Index.sync' ~hook:sync_hook ro;
+    Index.await thread |> check_completed;
+    Semaphore.release sync;
+    Index.check_binding ro k1 v1
+
   let tests =
     [
       ("add", `Quick, readonly);
@@ -536,6 +569,9 @@ module Readonly = struct
       ("readonly open after clear", `Quick, readonly_open_after_clear);
       ("race between sync and merge", `Quick, readonly_sync_and_merge);
       ("race between sync and clear", `Quick, readonly_io_clear);
+      ( "race between sync and end of merge",
+        `Quick,
+        readonly_sync_and_merge_clear );
     ]
 end
 


### PR DESCRIPTION
After a `clear` the files on disk should only contain the header  

For now this only works (and is tested) for the `data` file.