### PR TITLE
Specialise `v` to readonly and readwrite instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Changed
 
+- Specialise `IO.v` to create read-only or read-write instances. (#291)
+
 - Optimised the in-memory representation of index handles, resulting in a
   significant reduction in memory use. (#273)
 

--- a/src/checks.ml
+++ b/src/checks.ml
@@ -61,8 +61,8 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
     let with_io : type a. string -> (IO.t -> a) -> a option =
      fun path f ->
       match IO.v path with
-      | None -> None
-      | Some io ->
+      | Error `No_file_on_disk -> None
+      | Ok io ->
           let a = f io in
           IO.close io;
           Some a
@@ -118,8 +118,8 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
     let run ~root =
       let context = 2 in
       match IO.v (Layout.data ~root) with
-      | None -> Fmt.failwith "No data file in %s" root
-      | Some io ->
+      | Error `No_file_on_disk -> Fmt.failwith "No data file in %s" root
+      | Ok io ->
           let io_offset = IO.offset io in
           if Int63.compare io_offset encoded_sizeL < 0 then (
             if not (Int63.equal io_offset Int63.zero) then

--- a/src/checks.ml
+++ b/src/checks.ml
@@ -8,9 +8,7 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
     include Io.Extend (IO)
 
     (** This module never makes persistent changes *)
-    let v =
-      v ~fresh:false ~readonly:true ?flush_callback:None ~generation:Int63.zero
-        ~fan_size:Int63.zero
+    let v = v_readonly
 
     let page_size = Int63.of_int (Entry.encoded_size * 1000)
 
@@ -62,10 +60,9 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
 
     let with_io : type a. string -> (IO.t -> a) -> a option =
      fun path f ->
-      match IO.exists path with
-      | false -> None
-      | true ->
-          let io = IO.v path in
+      match IO.v path with
+      | None -> None
+      | Some io ->
           let a = f io in
           IO.close io;
           Some a
@@ -120,33 +117,35 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
 
     let run ~root =
       let context = 2 in
-      let io = IO.v (Layout.data ~root) in
-      let io_offset = IO.offset io in
-      if Int63.compare io_offset encoded_sizeL < 0 then (
-        if not (Int63.equal io_offset Int63.zero) then
-          Fmt.failwith
-            "Non-integer number of entries in file: { offset = %a; entry_size \
-             = %d }"
-            Int63.pp io_offset Entry.encoded_size)
-      else
-        let first_entry = IO.read_entry io Int63.zero in
-        let previous = ref first_entry in
-        Format.eprintf "\n%!";
-        Progress_unix.(
-          counter ~total:(Int63.to_int64 io_offset) ~mode:`UTF8
-            ~message:"Scanning store for faults" ~pp:Progress.Units.bytes
-            ~sampling_interval:100_000 ()
-          |> with_reporters)
-        @@ fun report ->
-        io
-        |> IO.iter ~min:encoded_sizeL (fun off e ->
-               report encoded_sizeLd;
-               if !previous.key_hash > e.key_hash then
-                 Log.err (fun f ->
-                     f "Found non-monotonic region:@,%a@,"
-                       (print_window_around off io context)
-                       ());
-               previous := e)
+      match IO.v (Layout.data ~root) with
+      | None -> Fmt.failwith "No data file in %s" root
+      | Some io ->
+          let io_offset = IO.offset io in
+          if Int63.compare io_offset encoded_sizeL < 0 then (
+            if not (Int63.equal io_offset Int63.zero) then
+              Fmt.failwith
+                "Non-integer number of entries in file: { offset = %a; \
+                 entry_size = %d }"
+                Int63.pp io_offset Entry.encoded_size)
+          else
+            let first_entry = IO.read_entry io Int63.zero in
+            let previous = ref first_entry in
+            Format.eprintf "\n%!";
+            Progress_unix.(
+              counter ~total:(Int63.to_int64 io_offset) ~mode:`UTF8
+                ~message:"Scanning store for faults" ~pp:Progress.Units.bytes
+                ~sampling_interval:100_000 ()
+              |> with_reporters)
+            @@ fun report ->
+            io
+            |> IO.iter ~min:encoded_sizeL (fun off e ->
+                   report encoded_sizeLd;
+                   if !previous.key_hash > e.key_hash then
+                     Log.err (fun f ->
+                         f "Found non-monotonic region:@,%a@,"
+                           (print_window_around off io context)
+                           ());
+                   previous := e)
 
     let term = Cmdliner.Term.(const (fun root () -> run ~root) $ path)
   end

--- a/src/index.ml
+++ b/src/index.ml
@@ -219,8 +219,8 @@ struct
         l "[%s] checking on-disk %s file" (Filename.basename t.root)
           (Filename.basename path));
     match IO.v_readonly path with
-    | None -> None
-    | Some io ->
+    | Error `No_file_on_disk -> None
+    | Ok io ->
         let mem = Tbl.create 0 in
         iter_io (fun e -> Tbl.replace mem e.key e.value) io;
         Some { io; mem }
@@ -253,8 +253,8 @@ struct
     Option.iter (fun (i : index) -> IO.close i.io) t.index;
     let index_path = Layout.data ~root:t.root in
     match IO.v_readonly index_path with
-    | None -> t.index <- None
-    | Some io ->
+    | Error `No_file_on_disk -> t.index <- None
+    | Ok io ->
         let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
         (* We maintain that [index] is [None] if the file is empty. *)
         if IO.offset io = Int63.zero then t.index <- None

--- a/src/index.ml
+++ b/src/index.ml
@@ -218,15 +218,12 @@ struct
     Log.debug (fun l ->
         l "[%s] checking on-disk %s file" (Filename.basename t.root)
           (Filename.basename path));
-    if IO.exists path then (
-      let io =
-        IO.v ~fresh:false ~readonly:true ~generation:Int63.zero
-          ~fan_size:Int63.zero path
-      in
-      let mem = Tbl.create 0 in
-      iter_io (fun e -> Tbl.replace mem e.key e.value) io;
-      Some { io; mem })
-    else None
+    match IO.v_readonly path with
+    | None -> None
+    | Some io ->
+        let mem = Tbl.create 0 in
+        iter_io (fun e -> Tbl.replace mem e.key e.value) io;
+        Some { io; mem }
 
   (** Loads the entries from [log]'s IO into memory, starting from offset [min]. *)
   let sync_log_entries ?min log =
@@ -255,18 +252,13 @@ struct
        changed after a merge. *)
     Option.iter (fun (i : index) -> IO.close i.io) t.index;
     let index_path = Layout.data ~root:t.root in
-    if IO.exists index_path then
-      let io =
-        IO.v ~fresh:false ~readonly:true ~generation:Int63.zero
-          ~fan_size:Int63.zero index_path
-        (* Only [readonly] and [fresh] are actually used in this
-           configuration. *)
-      in
-      let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-      (* We maintain that [index] is [None] if the file is empty. *)
-      if IO.offset io = Int63.zero then t.index <- None
-      else t.index <- Some { fan_out; io }
-    else t.index <- None
+    match IO.v_readonly index_path with
+    | None -> t.index <- None
+    | Some io ->
+        let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
+        (* We maintain that [index] is [None] if the file is empty. *)
+        if IO.offset io = Int63.zero then t.index <- None
+        else t.index <- Some { fan_out; io }
 
   (** Syncs an instance entirely, by checking on-disk changes for [log], [sync],
       and [log_async]. *)
@@ -474,27 +466,31 @@ struct
           log;
       IO.close io);
     let index =
-      let index_path = Layout.data ~root in
-      if IO.exists index_path then
-        let io =
-          (* NOTE: No [flush_callback] on the Index IO as we maintain the
-             invariant that any bindings it contains were previously persisted
-             in either [log] or [log_async]. *)
-          IO.v ?flush_callback:None ~fresh ~readonly ~generation
-            ~fan_size:Int63.zero index_path
-        in
-        let entries = Int63.div (IO.offset io) entry_sizeL in
-        if entries = Int63.zero then None
+      if readonly then None
+      else
+        let index_path = Layout.data ~root in
+        if IO.exists index_path then
+          let io =
+            (* NOTE: No [flush_callback] on the Index IO as we maintain the
+               invariant that any bindings it contains were previously persisted
+               in either [log] or [log_async]. *)
+            IO.v ?flush_callback:None ~fresh ~readonly ~generation
+              ~fan_size:Int63.zero index_path
+          in
+          let entries = Int63.div (IO.offset io) entry_sizeL in
+          if entries = Int63.zero then None
+          else (
+            Log.debug (fun l ->
+                l "[%s] index file detected. Loading %a entries"
+                  (Filename.basename root) Int63.pp entries);
+            let fan_out =
+              Fan.import ~hash_size:K.hash_size (IO.get_fanout io)
+            in
+            Some { fan_out; io })
         else (
           Log.debug (fun l ->
-              l "[%s] index file detected. Loading %a entries"
-                (Filename.basename root) Int63.pp entries);
-          let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-          Some { fan_out; io })
-      else (
-        Log.debug (fun l ->
-            l "[%s] no index file detected." (Filename.basename root));
-        None)
+              l "[%s] no index file detected." (Filename.basename root));
+          None)
     in
     {
       config;

--- a/src/index.ml
+++ b/src/index.ml
@@ -424,7 +424,7 @@ struct
       if readonly then if fresh then raise RO_not_allowed else None
       else
         let io =
-          IO.v ~flush_callback ~fresh ~readonly ~generation:Int63.zero
+          IO.v ~flush_callback ~fresh ~generation:Int63.zero
             ~fan_size:Int63.zero log_path
         in
         let entries = Int63.div (IO.offset io) entry_sizeL in
@@ -443,8 +443,8 @@ struct
        there is no need to do it here. *)
     if (not readonly) && IO.exists log_async_path then (
       let io =
-        IO.v ~flush_callback ~fresh ~readonly:false ~generation:Int63.zero
-          ~fan_size:Int63.zero log_async_path
+        IO.v ~flush_callback ~fresh ~generation:Int63.zero ~fan_size:Int63.zero
+          log_async_path
       in
       let entries = Int63.div (IO.offset io) entry_sizeL in
       Log.debug (fun l ->
@@ -474,8 +474,8 @@ struct
             (* NOTE: No [flush_callback] on the Index IO as we maintain the
                invariant that any bindings it contains were previously persisted
                in either [log] or [log_async]. *)
-            IO.v ?flush_callback:None ~fresh ~readonly ~generation
-              ~fan_size:Int63.zero index_path
+            IO.v ?flush_callback:None ~fresh ~generation ~fan_size:Int63.zero
+              index_path
           in
           let entries = Int63.div (IO.offset io) entry_sizeL in
           if entries = Int63.zero then None
@@ -671,7 +671,7 @@ struct
     let log_async =
       let io =
         let log_async_path = Layout.log_async ~root:t.root in
-        IO.v ~flush_callback:t.config.flush_callback ~fresh:true ~readonly:false
+        IO.v ~flush_callback:t.config.flush_callback ~fresh:true
           ~generation:(Int63.succ t.generation) ~fan_size:Int63.zero
           log_async_path
       in
@@ -722,7 +722,7 @@ struct
       in
       let merge =
         let merge_path = Layout.merge ~root:t.root in
-        IO.v ~fresh:true ~readonly:false ~generation
+        IO.v ~fresh:true ~generation
           ~fan_size:(Int63.of_int (Fan.exported_size fan_out))
           merge_path
       in
@@ -733,8 +733,8 @@ struct
             | `Abort -> `Aborted
             | `Continue ->
                 let io =
-                  IO.v ~fresh:true ~readonly:false ~generation
-                    ~fan_size:Int63.zero (Layout.data ~root:t.root)
+                  IO.v ~fresh:true ~generation ~fan_size:Int63.zero
+                    (Layout.data ~root:t.root)
                 in
                 append_remaining_log fan_out log_array 0 merge;
                 `Index_io io)

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -11,7 +11,7 @@ module type S = sig
     string ->
     t
 
-  val v_readonly : string -> t option
+  val v_readonly : string -> (t, [ `No_file_on_disk ]) result
 
   val offset : t -> int63
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -12,6 +12,8 @@ module type S = sig
     string ->
     t
 
+  val v_readonly : string -> t option
+
   val offset : t -> int63
 
   val read : t -> off:int63 -> len:int -> bytes -> int

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -5,7 +5,6 @@ module type S = sig
 
   val v :
     ?flush_callback:(unit -> unit) ->
-    readonly:bool ->
     fresh:bool ->
     generation:int63 ->
     fan_size:int63 ->

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -155,23 +155,24 @@ module IO : Index.IO = struct
 
   let () = assert (String.length current_version = 8)
 
-  let v ?(flush_callback = fun () -> ()) ~readonly ~fresh ~generation ~fan_size
-      file =
-    let v ~fan_size ~offset raw =
-      let eight = Int63.of_int 8 in
-      let header = eight ++ eight ++ eight ++ eight ++ fan_size in
-      {
-        header;
-        file;
-        offset;
-        raw;
-        readonly;
-        fan_size;
-        buf = Buffer.create (4 * 1024);
-        flushed = header ++ offset;
-        flush_callback;
-      }
-    in
+  let v_instance ?(flush_callback = fun () -> ()) ~readonly ~fan_size ~offset
+      file raw =
+    let eight = Int63.of_int 8 in
+    let header = eight ++ eight ++ eight ++ eight ++ fan_size in
+    {
+      header;
+      file;
+      offset;
+      raw;
+      readonly;
+      fan_size;
+      buf = Buffer.create (4 * 1024);
+      flushed = header ++ offset;
+      flush_callback;
+    }
+
+  let v ?flush_callback ~readonly ~fresh ~generation ~fan_size file =
+    let v = v_instance ?flush_callback ~readonly file in
     let mode = Unix.(if readonly then O_RDONLY else O_RDWR) in
     mkdir (Filename.dirname file);
     match Sys.file_exists file with
@@ -203,6 +204,31 @@ module IO : Index.IO = struct
           let offset = Raw.Offset.get raw in
           let fan_size = Raw.Fan.get_size raw in
           v ~fan_size ~offset raw
+
+  let v_readonly file =
+    let v = v_instance ~readonly:true file in
+    mkdir (Filename.dirname file);
+    try
+      let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; O_RDONLY ] 0o644 in
+      let raw = Raw.v x in
+      try
+        let version = Raw.Version.get raw in
+        if version <> current_version then
+          Fmt.failwith "Io.v: unsupported version %s (current version is %s)"
+            version current_version;
+        let offset = Raw.Offset.get raw in
+        let fan_size = Raw.Fan.get_size raw in
+        Some (v ~fan_size ~offset raw)
+      with Raw.Not_written ->
+        (* The readonly instance cannot read a file that does not have a
+           header.*)
+        Raw.close raw;
+        None
+    with
+    | Unix.Unix_error (Unix.ENOENT, _, _) ->
+        (* The readonly instance cannot open a non existing file. *)
+        None
+    | e -> raise e
 
   let exists = Sys.file_exists
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -215,16 +215,16 @@ module IO : Index.IO = struct
             version current_version;
         let offset = Raw.Offset.get raw in
         let fan_size = Raw.Fan.get_size raw in
-        Some (v ~fan_size ~offset raw)
+        Ok (v ~fan_size ~offset raw)
       with Raw.Not_written ->
         (* The readonly instance cannot read a file that does not have a
            header.*)
         Raw.close raw;
-        None
+        Error `No_file_on_disk
     with
     | Unix.Unix_error (Unix.ENOENT, _, _) ->
         (* The readonly instance cannot open a non existing file. *)
-        None
+        Error `No_file_on_disk
     | e -> raise e
 
   let exists = Sys.file_exists

--- a/src/unix/raw.ml
+++ b/src/unix/raw.ml
@@ -53,7 +53,10 @@ let encode_int63 n =
 
 let decode_int63 buf = Int63.decode ~off:0 buf
 
+exception Not_written
+
 let assert_read ~len n =
+  if n = 0 && n <> len then raise Not_written;
   assert (
     if Int.equal n len then true
     else (

--- a/src/unix/raw.mli
+++ b/src/unix/raw.mli
@@ -26,6 +26,8 @@ val close : t -> unit
 
 val fstat : t -> Unix.stats
 
+exception Not_written
+
 module Version : sig
   val get : t -> string
 

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -30,8 +30,7 @@ module IOArray = Index.Private.Io_array.Make (IO) (Entry)
 let entry = Alcotest.(pair string string)
 
 let fresh_io name =
-  IO.v ~readonly:false ~fresh:true ~generation:Int63.zero ~fan_size:Int63.zero
-    (root // name)
+  IO.v ~fresh:true ~generation:Int63.zero ~fan_size:Int63.zero (root // name)
 
 (* Append a random sequence of [size] keys to an IO instance and return
    a pair of an IOArray and an equivalent in-memory array. *)


### PR DESCRIPTION
extracted from https://github.com/mirage/index/pull/288.

I'm still not sure how the flaky tests in https://github.com/mirage/index/issues/268 and https://github.com/mirage/irmin/issues/1245 occur, but one possible explanation is that the readonly tries to read the header  of a file while that header is not yet written. This can happen if the file is being created simultaneously to a readonly trying to do a sync. 

This PR introduces a `v_readonly` that 
- eliminates the two steps (1) check if file exists and (2) then open it (the file might disappear between the two depending on how we implement `clear` );
- allows readonly to read the header - if the header is not yet written then readonly "acts" as if the file is not yet created.

I'm not sure we want to do this though (and we don't really need it for https://github.com/mirage/index/pull/288) but it might prevent some flaky tests from occurring. 