### PR TITLE
benchs: `replace_random_sync` in slow mode only

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -261,7 +261,7 @@ module Index = struct
         fresh = true;
         benchmark = write_sync;
         dependency = None;
-        speed = `Quick;
+        speed = `Slow;
       };
       {
         name = "replace_increasing_keys";


### PR DESCRIPTION
This bench flushes the idnex after each `replace`, this is not a behaviour that we use in production, so we can ignore this in quick mode.