### PR TITLE
expose header size

### DIFF
--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -35,6 +35,9 @@ module type S = sig
 
   val close : t -> unit
 
+  val size_header : t -> int
+  (** [size_header t] is [t]'s header size. *)
+
   module Lock : sig
     type t
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -233,6 +233,8 @@ module IO : Index.IO = struct
 
   let size { raw; _ } = (Raw.fstat raw).st_size
 
+  let size_header t = t.header |> Int63.to_int
+
   module Lock = struct
     type t = { path : string; fd : Unix.file_descr }
 


### PR DESCRIPTION
Expose in `IO` a function to get the size of the header of `data`. This necessary to implement a migration protocol from `data` towards another storing format (namely, for btrees).