### PR TITLE
Replay bootstrapping trace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendors/tezos-context-hash"]
+	path = vendors/tezos-context-hash
+	url = https://github.com/tarides/tezos-context-hash

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@
 - `clear` removes the files on disks and opens new ones containing only the
   header. (#288)
 
+## Added
+
+- Added benchmarks that replay a trace of index operations. (#300)
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/bench/common.ml
+++ b/bench/common.ml
@@ -1,0 +1,89 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+let reporter ?(prefix = "") () =
+  let report src level ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
+    let with_stamp h _tags k fmt =
+      let dt = Unix.gettimeofday () in
+      Fmt.kpf k ppf
+        ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
+        prefix dt Logs_fmt.pp_header (level, h)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src)
+    in
+    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k fmt
+  in
+  { Logs.report }
+
+let setup_log style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
+  Logs.set_reporter (reporter ());
+  ()
+
+module Seq = struct
+  include Seq
+
+  (* Backported from ocaml 4.11 *)
+  let rec unfold f u () =
+    match f u with None -> Nil | Some (x, u') -> Cons (x, unfold f u')
+end
+
+let with_timer f =
+  let t0 = Sys.time () in
+  let a = f () in
+  let t1 = Sys.time () -. t0 in
+  (t1, a)
+
+let with_progress_bar ~sampling_interval ~message ~n ~unit =
+  let bar =
+    let w =
+      if n = 0 then 1
+      else float_of_int n |> log10 |> floor |> int_of_float |> succ
+    in
+    let pp fmt i = Format.fprintf fmt "%*Ld/%*d %s" w i w n unit in
+    let pp f = f ~width:(w + 1 + w + 1 + String.length unit) pp in
+    Progress_unix.counter ~sampling_interval ~mode:`ASCII ~width:79
+      ~total:(Int64.of_int n) ~message ~pp ()
+  in
+  Progress_unix.with_reporters bar
+
+module FSHelper = struct
+  let file f =
+    try (Unix.stat f).st_size with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
+
+  let index root =
+    let index_dir = Filename.concat root "index" in
+    let a = file (Filename.concat index_dir "data") in
+    let b = file (Filename.concat index_dir "log") in
+    let c = file (Filename.concat index_dir "log_async") in
+    (a + b + c) / 1024 / 1024
+
+  let size root = index root
+  let get_size root = size root
+
+  let rm_dir root =
+    if Sys.file_exists root then (
+      let cmd = Printf.sprintf "rm -rf %s" root in
+      Logs.info (fun l -> l "exec: %s" cmd);
+      let _ = Sys.command cmd in
+      ())
+end

--- a/bench/dune
+++ b/bench/dune
@@ -1,10 +1,16 @@
 (executable
  (public_name bench)
+ (modules bench)
  (package index-bench)
  (preprocess
   (pps ppx_repr ppx_deriving_yojson))
  (libraries index index.unix cmdliner metrics metrics-unix yojson fmt re
    stdlib-shims))
+
+(library
+ (name common)
+ (modules common)
+ (libraries progress progress.unix logs fmt))
 
 (alias
  (name bench)
@@ -14,3 +20,19 @@
  (alias runbench)
  (action
   (run ./bench.exe)))
+
+(executable
+ (name replay)
+ (modules replay)
+ (preprocess
+  (pps ppx_repr))
+ (libraries index index.unix unix cmdliner logs repr ppx_repr common
+   tezos-context-hash optint fmt rusage))
+
+;; Require the above executables to compile during tests
+
+(rule
+ (alias runtest)
+ (package index-bench)
+ (deps bench.exe replay.exe)
+ (action (progn)))

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -1,0 +1,261 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Common
+
+module Encoding = struct
+  module Hash = Tezos_context_hash.Hash
+
+  module Key : Index.Key.S with type t = Hash.t = struct
+    type t = Hash.t [@@deriving repr]
+
+    let hash = Repr.(unstage (short_hash Hash.t)) ?seed:None
+    let hash_size = 30
+    let equal = Repr.(unstage (equal Hash.t))
+    let encode = Repr.(unstage (to_bin_string Hash.t))
+    let encoded_size = Hash.hash_size
+    let decode_bin = Repr.(unstage (decode_bin Hash.t))
+
+    let decode s off =
+      let _, v = decode_bin s off in
+      v
+  end
+
+  module Int63 = struct
+    include Optint.Int63
+
+    let t : t Repr.t =
+      let open Repr in
+      (map int64) of_int64 to_int64
+      |> like ~pp:Optint.Int63.pp ~equal:(stage Optint.Int63.equal)
+           ~compare:(stage Optint.Int63.compare)
+  end
+
+  type int63 = Int63.t [@@deriving repr]
+
+  module Val = struct
+    type t = int63 * int * char [@@deriving repr]
+
+    let to_bin_string =
+      Repr.(unstage (to_bin_string (triple int63_t int32 char)))
+
+    let encode (off, len, kind) = to_bin_string (off, Int32.of_int len, kind)
+    let decode_bin = Repr.(unstage (decode_bin (triple int63_t int32 char)))
+
+    let decode s off =
+      let off, len, kind = snd (decode_bin s off) in
+      (off, Int32.to_int len, kind)
+
+    let encoded_size = (64 / 8) + (32 / 8) + 1
+  end
+end
+
+let decoded_seq_of_encoded_chan_with_prefixes :
+    'a Repr.ty -> in_channel -> 'a Seq.t =
+ fun repr channel ->
+  let decode_bin = Repr.decode_bin repr |> Repr.unstage in
+  let decode_prefix = Repr.(decode_bin int32 |> unstage) in
+  let produce_op () =
+    try
+      (* First read the prefix *)
+      let prefix = really_input_string channel 4 in
+      let len', len = decode_prefix prefix 0 in
+      assert (len' = 4);
+      let len = Int32.to_int len in
+      (* Then read the repr *)
+      let content = really_input_string channel len in
+      let len', op = decode_bin content 0 in
+      assert (len' = len);
+      Some (op, ())
+    with End_of_file -> None
+  in
+  Seq.unfold produce_op ()
+
+type int63 = Encoding.int63 [@@deriving repr]
+type config = { nb_ops : int; trace_data_file : string; root : string }
+
+module Trace = struct
+  type key = string [@@deriving repr]
+
+  type op =
+    | Clear
+    | Flush
+    | Mem of key * bool
+    | Find of key * bool
+    | Ro_mem of key * bool
+    | Ro_find of key * bool
+    | Add of key * (int63 * int * char)
+  [@@deriving repr]
+
+  let open_ops_sequence path : op Seq.t =
+    let chan = open_in_bin path in
+    decoded_seq_of_encoded_chan_with_prefixes op_t chan
+end
+
+module Benchmark = struct
+  type result = { time : float; size : int }
+
+  let run config f =
+    let time, res = with_timer f in
+    let size = FSHelper.get_size config.root in
+    ({ time; size }, res)
+
+  let get_maxrss () =
+    let usage = Rusage.(get Self) in
+    let ( / ) = Int64.div in
+    usage.maxrss / 1024L / 1024L
+
+  let pp_results ppf result =
+    Format.fprintf ppf "Total time: %f; Size on disk: %d M; Maxrss: %Ld"
+      result.time result.size (get_maxrss ())
+end
+
+module type S = sig
+  include Index.S
+
+  val v : string -> t
+  val close : t -> unit
+end
+
+module Index = struct
+  module Index =
+    Index_unix.Make (Encoding.Key) (Encoding.Val) (Index.Cache.Unbounded)
+
+  include Index
+
+  let cache = Index.empty_cache ()
+  let v root = Index.v ~cache ~readonly:false ~fresh:true ~log_size:500_000 root
+  let close t = Index.close t
+end
+
+module Bench_suite
+    (Store : S
+               with type key = Encoding.Hash.t
+                and type value = int63 * int * char) =
+struct
+  let key_to_hash k =
+    match Encoding.Hash.of_string k with
+    | Ok k -> k
+    | Error (`Msg m) -> Fmt.failwith "error decoding hash %s" m
+
+  let add_operation store op_seq nb_ops () =
+    let sampling_interval = nb_ops / 1000 in
+    with_progress_bar ~sampling_interval ~message:"Replaying trace" ~n:nb_ops
+      ~unit:"operations"
+    @@ fun progress ->
+    let rec aux op_seq i =
+      if i >= nb_ops then i
+      else
+        match op_seq () with
+        | Seq.Nil -> i
+        | Cons (op, op_seq) ->
+            let () =
+              match op with
+              | Trace.Flush -> Store.flush store
+              | Clear -> Store.clear store
+              | Mem (k, b) ->
+                  let k = key_to_hash k in
+                  let b' = Store.mem store k in
+                  if b <> b' then
+                    Fmt.failwith "Operation mem %a expected %b got %b"
+                      (Repr.pp Encoding.Key.t) k b b'
+              | Find (k, b) ->
+                  let k = key_to_hash k in
+                  let b' =
+                    try
+                      let _ = Store.find store k in
+                      true
+                    with Not_found -> false
+                  in
+                  if b <> b' then
+                    Fmt.failwith "Operation find %a expected %b got %b"
+                      (Repr.pp Encoding.Key.t) k b b'
+              | Add (k, v) ->
+                  let k = key_to_hash k in
+                  Store.replace store k v
+              | Ro_mem _ | Ro_find _ -> ()
+            in
+            progress Int64.one;
+            aux op_seq (i + 1)
+    in
+    aux op_seq 0
+
+  let run_read_trace config =
+    let op_seq = Trace.open_ops_sequence config.trace_data_file in
+    let store = Store.v config.root in
+
+    let result, nb_ops =
+      add_operation store op_seq config.nb_ops |> Benchmark.run config
+    in
+
+    let () = Store.close store in
+
+    fun ppf ->
+      Format.fprintf ppf "Tezos trace for %d nb_ops @\nResults: @\n%a@\n" nb_ops
+        Benchmark.pp_results result
+end
+
+module Bench = Bench_suite (Index)
+
+let main () nb_ops trace_data_file =
+  Printexc.record_backtrace true;
+  Random.self_init ();
+  let root = "_bench_replay" in
+  FSHelper.rm_dir root;
+  let config = { trace_data_file; root; nb_ops } in
+  let results = Bench.run_read_trace config in
+  Logs.app (fun l -> l "%a@." (fun ppf f -> f ppf) results)
+
+open Cmdliner
+
+let nb_ops =
+  let doc =
+    Arg.info ~doc:"Number of operations to read from trace." [ "ops" ]
+  in
+  Arg.(value @@ opt int 2 doc)
+
+let trace_data_file =
+  let doc =
+    Arg.info ~docv:"PATH" ~doc:"Trace of Tezos operations to be replayed." []
+  in
+  Arg.(required @@ pos 0 (some string) None doc)
+
+let setup_log =
+  Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
+
+let main_term = Term.(const main $ setup_log $ nb_ops $ trace_data_file)
+
+let () =
+  let man =
+    [
+      `S "DESCRIPTION";
+      `P
+        "Benchmarks for index operations. Requires traces of operations\n\
+        \         download them (`wget trace.repr`) from: ";
+      `P
+        "Trace with $(b,401,253,899) operations \
+         http://data.tarides.com/index/trace_401253899.repr";
+      `P
+        "Trace with $(b,544,766,125) operations \
+         http://data.tarides.com/index/trace_544766125.repr";
+    ]
+  in
+  let info =
+    Term.info ~man
+      ~doc:"Replay index operations done by the bootstrapping of a tezos node"
+      "replay-index"
+  in
+  Term.exit @@ Term.eval (main_term, info)

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(vendored_dirs vendors)

--- a/index-bench.opam
+++ b/index-bench.opam
@@ -1,23 +1,16 @@
 opam-version: "2.0"
-maintainer:   "Clement Pascutto"
-authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
-license:      "MIT"
-homepage:     "https://github.com/mirage/index"
-bug-reports:  "https://github.com/mirage/index/issues"
-dev-repo:     "git+https://github.com/mirage/index.git"
-
-build: [
- ["dune" "subst"] {dev}
- ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
-]
-
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
 depends: [
-  "ocaml"   {>= "4.03.0"}
+  "ocaml" {>= "4.03.0"}
   "cmdliner"
-  "dune"    {>= "2.7.0"}
+  "dune" {>= "2.7.0"}
   "fmt"
-  "index"   {= version}
+  "index" {= version}
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"
@@ -25,6 +18,16 @@ depends: [
   "stdlib-shims"
   "yojson"
   "ppx_repr"
+  "tezos-context-hash"
+  "logs" {>= "0.7.0" & with-test}
+  "optint" {>= "0.1.0" & with-test}
+  "progress" {>= "0.1.1" & with-test}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
 ]
-
-synopsis: "Index benchmarking suite"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"


### PR DESCRIPTION
Initial benchmarks for replaying the trace of index operations during bootstrap. The trace is small for now, I’m working on getting a bigger one.

It needs the dependency on `tezos-context-hash` but only on the Hash module, and it needs to be in a separate package (https://github.com/icristescu/tezos-context-hash/tree/hash_pkg); Otherwise, we end up with the following dune error:

```
Error: Conflict between the following libraries:
- "index" in _build/default/src
- "index" in /Users/icristes/.opam/4.11.0/lib/index
  -> required by library "irmin-pack" in
     /Users/icristes/.opam/4.11.0/lib/irmin-pack
  -> required by library "tezos-context-hash" in
     _build/default/vendors/tezos-context-hash/src
-> required by executable replay in bench/dune:25

```
