### PR TITLE
Crash-consistency bug fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Fixed
+
+- Fixed a crash-consistency bug due to a potential flush of an incomplete entry
+  to disk. Entries are now flushed as complete strings. (#301)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)

--- a/src/data.ml
+++ b/src/data.ml
@@ -94,8 +94,7 @@ module Entry = struct
         raise (Invalid_size encoded_key);
       if String.length encoded_value <> V.encoded_size then
         raise (Invalid_size encoded_value);
-      f encoded_key;
-      f encoded_value
+      f (encoded_key ^ encoded_value)
 
     let encode { key; value; _ } f = encode' key value f
   end


### PR DESCRIPTION
```ocaml
(* Entry *)
let encode' key value f =
  f (K.encode key);
  (* Flush possible. Crash-consistency bug *)
  f (V.encode value)
```

Called like this:

```ocaml
Entry.encode' key value (IO.append t)
```
with
```ocaml
let append t buf =
  Buffer.add_string t.buf buf;
  flush t (* if offset is high enough *)
```

This means that the encoding function takes a writing function `f` and applies it to the encoding. If this function `f` flushes a flush may occur and if a crash happens at the same time the flushed encoding will be incomplete (the key will have been written but not the value)

The easiest way to prevent it is to call `f` on the concatenation of the two encoding since this won't induce any API change.

Since `Repr.encode` will change in a near future, the priority is to fix this bug and work on the encoding once `Repr.encode` has been changed.