### PR TITLE
Simplifications on top of #288

### DIFF
--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -14,7 +14,10 @@ module type S = sig
   val v_readonly : string -> (t, [ `No_file_on_disk ]) result
   val offset : t -> int63
   val read : t -> off:int63 -> len:int -> bytes -> int
-  val clear : generation:int63 -> ?hook:(unit -> unit) -> t -> unit
+
+  val clear :
+    generation:int63 -> ?hook:(unit -> unit) -> reopen:bool -> t -> unit
+
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
   val get_generation : t -> int63
   val set_fanout : t -> string -> unit

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -157,7 +157,7 @@ module IO : Index.IO = struct
     t.flushed <- t.header;
     Buffer.clear t.buf;
     (* Remove the file current file. This allows a fresh file to be
-       created, before writing the new generation in the temporary file. *)
+       created, before writing the new generation in the old file. *)
     let old = t.raw in
     Unix.unlink t.file;
     (* Open a fresh file. *)

--- a/test/cli/stat.t/run.t
+++ b/test/cli/stat.t/run.t
@@ -29,12 +29,6 @@ Running `stat` on an index after 10 merges:
         "generation": 9,
         "fanout_size": "0.0 B"
       },
-      "log_async": {
-        "size": "32.0 B",
-        "offset": 0,
-        "generation": 10,
-        "fanout_size": "0.0 B"
-      },
       "lock": "<PID>"
     }
   }

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -128,16 +128,21 @@ module Live = struct
     Index.clear rw;
     Index.close rw;
     let module I = Index_unix.Private.IO in
-    let test path msg =
+    let test_there path =
       match I.v_readonly path with
-      | Error `No_file_on_disk -> Alcotest.fail "expected data file"
+      | Error `No_file_on_disk -> Alcotest.failf "expected file: %s" path
       | Ok data ->
-          Alcotest.(check int) msg (I.size data) (I.size_header data);
+          Alcotest.(check int) path (I.size data) (I.size_header data);
           I.close data
     in
-    test (Layout.log ~root) "size of log file";
-    test (Layout.log_async ~root) "size of log_async file";
-    test (Layout.data ~root) "size of data file"
+    let test_not_there path =
+      match I.v_readonly path with
+      | Error `No_file_on_disk -> ()
+      | Ok _ -> Alcotest.failf "do not expect file: %s" path
+    in
+    test_there (Layout.log ~root);
+    test_not_there (Layout.log_async ~root);
+    test_not_there (Layout.data ~root)
 
   let duplicate_entries () =
     let* Context.{ rw; _ } = Context.with_empty_index () in


### PR DESCRIPTION
We don't need to create a temporary file, it's fine to just remove
the initial file while holding an open file descriptor on the resource.

We also can directly remove the files which are not needed after a clear:
only the log file is needed as it contains the current generation number.