### PR TITLE
use fsync to flush metadata when reoperning a file with new headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
   progress: the `log_async` file was not cached properly and fully reloaded
   from disk every time. (#310)
 
+- Added fsync after `Index.clear` to signal more quickly to read-only instances
+  than something has changed in the file (#308)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)


### PR DESCRIPTION
Not totally sure about this one: this will probably slow down single writer/multiple instances within the same process (but probably not much as this is not a very common operation) ; but that'll speed up signalling of when a merge is done for other processes opened in read-only mode.