### PR TITLE
Do not reload log_async on every sync

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Fixed a crash-consistency bug due to a potential flush of an incomplete entry
   to disk. Entries are now flushed as complete strings. (#301)
 
+- Fixed a performance issue for `Index.sync` when there is a blocking merge in
+  progress: the `log_async` file was not cached properly and fully reloaded
+  from disk every time. (#310)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)

--- a/src/index.ml
+++ b/src/index.ml
@@ -238,8 +238,12 @@ struct
     | Some log ->
         let offset = IO.offset log.io in
         let h = IO.Header.get log.io in
-        (* If the generation has changed *)
-        if t.generation <> h.generation then (
+        if
+          (* the generation has changed *)
+          h.generation > Int63.succ t.generation
+          || (* the last sync was done between clear(log) and clear(log_async) *)
+          (h.generation = Int63.succ t.generation && h.offset = Int63.zero)
+        then (
           (* close the file .*)
           IO.close log.io;
           (* check that file is on disk, reopen and reload everything. *)

--- a/src/index.ml
+++ b/src/index.ml
@@ -230,9 +230,11 @@ struct
     iter_io ?min add_log_entry log.io
 
   (** Syncs the [log_async] of the instance by checking on-disk changes. *)
-  let sync_log_async t =
+  let sync_log_async ~hook t =
     match t.log_async with
-    | None -> t.log_async <- try_load_log t (Layout.log_async ~root:t.root)
+    | None ->
+        hook `Reload_log_async;
+        t.log_async <- try_load_log t (Layout.log_async ~root:t.root)
     | Some log ->
         let offset = IO.offset log.io in
         let h = IO.Header.get log.io in
@@ -241,6 +243,7 @@ struct
           (* close the file .*)
           IO.close log.io;
           (* check that file is on disk, reopen and reload everything. *)
+          hook `Reload_log_async;
           t.log_async <- try_load_log t (Layout.log_async ~root:t.root)
           (* else if the disk offset is greater, reload the newest data. *))
         else if offset < h.offset then sync_log_entries ~min:offset log
@@ -287,7 +290,7 @@ struct
        worse, [log_async] and [log] might contain duplicated entries,
        but we won't miss any. These entries will be added to [log.mem]
        using Tbl.replace where they will be deduplicated. *)
-    sync_log_async t;
+    sync_log_async ~hook t;
     match t.log with
     | None -> ()
     | Some log ->
@@ -303,6 +306,7 @@ struct
               l "[%s] generation has changed: %a -> %a"
                 (Filename.basename t.root) Int63.pp t.generation Int63.pp
                 h.generation);
+          hook `Reload_log;
           t.generation <- h.generation;
           IO.close log.io;
           t.log <- try_load_log t (Layout.log ~root:t.root);

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -255,7 +255,14 @@ module type Private = sig
       [sampling_interval] is not set, no operation is timed. *)
 
   val sync' :
-    ?hook:[ `Before_offset_read | `After_offset_read ] hook -> t -> unit
+    ?hook:
+      [ `Before_offset_read
+      | `After_offset_read
+      | `Reload_log
+      | `Reload_log_async ]
+      hook ->
+    t ->
+    unit
   (** Hooks:
 
       - [`Before_offset_read]: before reading the generation number and the

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -552,6 +552,46 @@ module Readonly = struct
     Semaphore.release sync;
     Index.check_binding ro k1 v1
 
+  let reload_log_async () =
+    let* Context.{ rw; clone; _ } = Context.with_empty_index () in
+    let ro = clone ~readonly:true () in
+    let reload_log = ref 0 in
+    let reload_log_async = ref 0 in
+    let merge = Semaphore.make false in
+    let sync = Semaphore.make false in
+    let merge_hook =
+      I.Private.Hook.v @@ function
+      | `Before ->
+          Semaphore.release sync;
+          Semaphore.acquire merge
+      | `After_clear -> Semaphore.release sync
+      | _ -> ()
+    in
+    let sync_hook =
+      I.Private.Hook.v (function
+        | `Reload_log -> reload_log := succ !reload_log
+        | `Reload_log_async -> reload_log_async := succ !reload_log_async
+        | _ -> ())
+    in
+    let k1, v1 = (Key.v (), Value.v ()) in
+    let k2, v2 = (Key.v (), Value.v ()) in
+    Index.replace rw k1 v1;
+    Index.flush rw;
+    let t = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
+    Index.replace rw k2 v2;
+    Index.flush rw;
+    Semaphore.acquire sync;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Semaphore.release merge;
+    Index.check_binding ro k1 v1;
+    Index.check_binding ro k2 v2;
+    Alcotest.(check int) "reloadings of log per merge" 0 !reload_log;
+    Alcotest.(check int) "reloadings of log async per merge" 1 !reload_log_async;
+    Index.await t |> check_completed
+
   let tests =
     [
       ("add", `Quick, readonly);
@@ -577,6 +617,7 @@ module Readonly = struct
       ( "race between sync and end of merge",
         `Quick,
         readonly_sync_and_merge_clear );
+      ("reload log and log async", `Quick, reload_log_async);
     ]
 end
 


### PR DESCRIPTION
 Do not reload log_async on every sync

In general `generation(log_async)` is `generation(log) + 1`. So a read-only instance needs to reload a the `log_async` file only if the diff > 2.

There is also a small race between sync and merge: Merge is performing `clear(log)` then `clear(log_async)` which both bump the generation number. Between these two clears, `generation(log_async) = generation(log)`. So the sync operation also checks if the diff is > 1 and if a `clear(log_async)` has just completed (clear sets `offset` to 0 and unlink the file so noone else could write on it).

Fix #296 