### PR TITLE
Gitignore opam/ even if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 _bench/
 _build/
 _metrics/
-_opam/
+_opam
 _tests/
 *.install
 *.merlin


### PR DESCRIPTION
This happens when using `opam switch link`.