### PR TITLE
Raise exceptions on failed Int63.to_int coercions

### DIFF
--- a/src/import.ml
+++ b/src/import.ml
@@ -1,3 +1,20 @@
-module Int63 = Optint.Int63
+module Int63 = struct
+  include Optint.Int63
+
+  let ( + ) = add
+  let ( - ) = sub
+  let ( * ) = mul
+  let ( / ) = div
+
+  let to_int_exn =
+    let max_int = of_int Int.max_int in
+    fun x ->
+      if compare x max_int > 0 then
+        Fmt.failwith "Int63.to_int_exn: %a too large" pp x
+      else to_int x
+
+  let to_int_trunc = to_int
+  let to_int = `shadowed
+end
 
 type int63 = Int63.t

--- a/src/index.ml
+++ b/src/index.ml
@@ -446,11 +446,11 @@ struct
           IO.v ~flush_callback ~fresh ~generation:Int63.zero
             ~fan_size:Int63.zero log_path
         in
-        let entries = Int63.div (IO.offset io) entry_sizeL in
+        let entries = Int63.(to_int_exn (IO.offset io / entry_sizeL)) in
         Log.debug (fun l ->
-            l "[%s] log file detected. Loading %a entries"
-              (Filename.basename root) Int63.pp entries);
-        let mem = Tbl.create (Int63.to_int entries) in
+            l "[%s] log file detected. Loading %d entries"
+              (Filename.basename root) entries);
+        let mem = Tbl.create entries in
         iter_io (fun e -> Tbl.replace mem e.key e.value) io;
         Some { io; mem }
     in
@@ -708,7 +708,7 @@ struct
       match t.index with
       | None -> Tbl.length log.mem
       | Some index ->
-          (Int63.to_int (IO.offset index.io) / Entry.encoded_size)
+          Int63.(to_int_exn (IO.offset index.io / entry_sizeL))
           + Array.length log_array
     in
     let fan_out =

--- a/src/io.ml
+++ b/src/io.ml
@@ -27,7 +27,7 @@ module Extend (S : S) = struct
       let remaining = Int63.sub max_off offset in
       if remaining <= Int63.zero then ()
       else
-        let len = Int63.to_int (min remaining page_size) in
+        let len = Int63.to_int_exn (min remaining page_size) in
         let raw = Bytes.create len in
         let n = read io ~off:offset ~len raw in
         let rec read_page page off =


### PR DESCRIPTION
Fixes the bug spotted here: https://github.com/mirage/index/pull/312#discussion_r622221691 (not that anyone's likely to have run into it). I think `Int63.to_int` is a little too tempting from an API perspective, so I've shadowed it and provided more clearly named checked and unchecked alternatives.