### PR TITLE
Prepare 1.3.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.16.0
+version = 0.18.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Reduce allocations during merge (#274, #277)
 
+- Protect concurrent syncs with a lock (#309)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - Specialise `IO.v` to create read-only or read-write instances. (#291)
 
 - `clear` removes the files on disks and opens new ones containing only the
-  header. (#288, #307)
+  header. (#288, #307, #317)
 
 # 1.3.0 (2021-01-05)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Specialise `IO.v` to create read-only or read-write instances. (#291)
 
 - `clear` removes the files on disks and opens new ones containing only the
-  header. (#288)
+  header. (#288, #307)
 
 # 1.3.0 (2021-01-05)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)
 
+- `clear` removes the files on disks and opens new ones containing only the
+  header. (#288)
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Protect concurrent syncs with a lock (#309)
 
+- Fixed a performance issue for `Index.sync` when there is a blocking merge in
+  progress: the `log_async` file was not cached properly and fully reloaded
+  from disk every time. (#310)
+
 - Release the merge lock if a merge raises an exception (#312)
 
 ## Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 
 - Release the merge lock if a merge raises an exception (#312)
 
+- Added fsync after `Index.clear` to signal more quickly to read-only instances
+  than something has changed in the file (#308)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Fixed
+
+- Reduce allocations during merge (#274, #277)
+
+## Changed
+
+- Specialise `IO.v` to create read-only or read-write instances. (#291)
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Protect concurrent syncs with a lock (#309)
 
+- Release the merge lock if a merge raises an exception (#312)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)

--- a/src/checks.ml
+++ b/src/checks.ml
@@ -60,8 +60,8 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
     let with_io : type a. string -> (IO.t -> a) -> a option =
      fun path f ->
       match IO.v path with
-      | None -> None
-      | Some io ->
+      | Error `No_file_on_disk -> None
+      | Ok io ->
           let a = f io in
           IO.close io;
           Some a
@@ -113,8 +113,8 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
     let run ~root =
       let context = 2 in
       match IO.v (Layout.data ~root) with
-      | None -> Fmt.failwith "No data file in %s" root
-      | Some io ->
+      | Error `No_file_on_disk -> Fmt.failwith "No data file in %s" root
+      | Ok io ->
           let io_offset = IO.offset io in
           if Int64.compare io_offset encoded_sizeL < 0 then (
             if not (Int64.equal io_offset 0L) then

--- a/src/data.ml
+++ b/src/data.ml
@@ -57,6 +57,10 @@ module Entry = struct
 
     val decode : string -> int -> t
 
+    val decode_key : string -> int -> key * int
+
+    val decode_value : string -> int -> value
+
     val encode : t -> (string -> unit) -> unit
 
     val encode' : key -> value -> (string -> unit) -> unit
@@ -74,6 +78,12 @@ module Entry = struct
       let key = K.decode string off in
       let value = V.decode string (off + K.encoded_size) in
       { key; key_hash = K.hash key; value }
+
+    let decode_key string off =
+      let key = K.decode string off in
+      (key, K.hash key)
+
+    let decode_value string off = V.decode string (off + K.encoded_size)
 
     let encode' key value f =
       let encoded_key = K.encode key in

--- a/src/data.ml
+++ b/src/data.ml
@@ -92,8 +92,7 @@ module Entry = struct
         raise (Invalid_size encoded_key);
       if String.length encoded_value <> V.encoded_size then
         raise (Invalid_size encoded_value);
-      f encoded_key;
-      f encoded_value
+      f (encoded_key ^ encoded_value)
 
     let encode { key; value; _ } f = encode' key value f
   end

--- a/src/data.ml
+++ b/src/data.ml
@@ -64,6 +64,7 @@ module Entry = struct
     val encode : t -> (string -> unit) -> unit
 
     val encode' : key -> value -> (string -> unit) -> unit
+
     val compare : t -> t -> int
     (* Compare entries by their key hash. *)
   end
@@ -97,6 +98,7 @@ module Entry = struct
       f (encoded_key ^ encoded_value)
 
     let encode { key; value; _ } f = encode' key value f
+
     let compare a b = Int.compare a.key_hash b.key_hash
   end
 end

--- a/src/data.ml
+++ b/src/data.ml
@@ -64,6 +64,8 @@ module Entry = struct
     val encode : t -> (string -> unit) -> unit
 
     val encode' : key -> value -> (string -> unit) -> unit
+    val compare : t -> t -> int
+    (* Compare entries by their key hash. *)
   end
 
   module Make (K : Key) (V : Value) :
@@ -95,6 +97,7 @@ module Entry = struct
       f (encoded_key ^ encoded_value)
 
     let encode { key; value; _ } f = encode' key value f
+    let compare a b = Int.compare a.key_hash b.key_hash
   end
 end
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -234,8 +234,12 @@ struct
     | Some log ->
         let offset = IO.offset log.io in
         let h = IO.Header.get log.io in
-        (* If the generation has changed *)
-        if t.generation <> h.generation then (
+        if
+          (* the generation has changed *)
+          h.generation > Int64.succ t.generation
+          || (* the last sync was done between clear(log) and clear(log_async) *)
+          (h.generation = Int64.succ t.generation && h.offset = 0L)
+        then (
           (* close the file .*)
           IO.close log.io;
           (* check that file is on disk, reopen and reload everything. *)

--- a/src/index.ml
+++ b/src/index.ml
@@ -214,8 +214,8 @@ struct
         l "[%s] checking on-disk %s file" (Filename.basename t.root)
           (Filename.basename path));
     match IO.v_readonly path with
-    | None -> None
-    | Some io ->
+    | Error `No_file_on_disk -> None
+    | Ok io ->
         let mem = Tbl.create 0 in
         iter_io (fun e -> Tbl.replace mem e.key e.value) io;
         Some { io; mem }
@@ -239,8 +239,8 @@ struct
     Option.iter (fun (i : index) -> IO.close i.io) t.index;
     let index_path = Layout.data ~root:t.root in
     match IO.v_readonly index_path with
-    | None -> t.index <- None
-    | Some io ->
+    | Error `No_file_on_disk -> t.index <- None
+    | Ok io ->
         let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
         (* We maintain that [index] is [None] if the file is empty. *)
         if IO.offset io = 0L then t.index <- None

--- a/src/index.ml
+++ b/src/index.ml
@@ -287,6 +287,8 @@ struct
           t.generation <- h.generation;
           IO.close log.io;
           t.log <- try_load_log t (Layout.log ~root:t.root);
+          (* The log file is never removed (even by clear). *)
+          assert (t.log <> None);
           sync_index t)
         else if log_offset < h.offset then (
           Log.debug (fun l ->

--- a/src/index.ml
+++ b/src/index.ml
@@ -573,14 +573,125 @@ struct
       incr n;
       !n
 
+  (** Merges the entries in [t.log] into the data file, ensuring that concurrent
+      writes are not lost.
+
+      The caller must ensure the following:
+
+      - [t.log] has been loaded;
+      - [t.log_async] has been created;
+      - [t.merge_lock] is acquired before entry, and released immediately after
+        this function returns or raises an exception. *)
+  let compare_entry (e : Entry.t) (e' : Entry.t) =
+    compare e.key_hash e'.key_hash
+
+  let unsafe_perform_merge ~witness ~filter ~hook t =
+    hook `Before;
+    let log = Option.get t.log in
+    let generation = Int64.succ t.generation in
+    let log_array =
+      Option.iter
+        (fun f ->
+          Tbl.filter_map_inplace
+            (fun key value -> if f (key, value) then Some value else None)
+            log.mem)
+        filter;
+      let b = Array.make (Tbl.length log.mem) witness in
+      Tbl.fold
+        (fun key value i ->
+          b.(i) <- Entry.v key value;
+          i + 1)
+        log.mem 0
+      |> ignore;
+      Array.fast_sort compare_entry b;
+      b
+    in
+    let fan_size =
+      match t.index with
+      | None -> Tbl.length log.mem
+      | Some index ->
+          (Int64.to_int (IO.offset index.io) / Entry.encoded_size)
+          + Array.length log_array
+    in
+    let fan_out =
+      Fan.v ~hash_size:K.hash_size ~entry_size:Entry.encoded_size fan_size
+    in
+    let merge =
+      let merge_path = Layout.merge ~root:t.root in
+      IO.v ~fresh:true ~generation
+        ~fan_size:(Int64.of_int (Fan.exported_size fan_out))
+        merge_path
+    in
+    let merge_result : [ `Index_io of IO.t | `Aborted ] =
+      match t.index with
+      | None -> (
+          match check_pending_cancel t with
+          | `Abort -> `Aborted
+          | `Continue ->
+              let io =
+                IO.v ~fresh:true ~generation ~fan_size:0L
+                  (Layout.data ~root:t.root)
+              in
+              append_remaining_log fan_out log_array 0 merge;
+              `Index_io io)
+      | Some index -> (
+          match
+            merge_with ~hook
+              ~yield:(fun () -> check_pending_cancel t)
+              ~filter log_array index.io fan_out merge
+          with
+          | `Completed -> `Index_io index.io
+          | `Aborted -> `Aborted)
+    in
+    match merge_result with
+    | `Aborted -> (`Aborted, Mtime.Span.zero)
+    | `Index_io io ->
+        let fan_out = Fan.finalize fan_out in
+        let index = { io; fan_out } in
+        IO.set_fanout merge (Fan.export index.fan_out);
+        let before_rename_lock = Mtime_clock.counter () in
+        let rename_lock_duration =
+          Semaphore.with_acquire "merge-rename" t.rename_lock (fun () ->
+              let rename_lock_duration = Mtime_clock.count before_rename_lock in
+              IO.rename ~src:merge ~dst:index.io;
+              t.index <- Some index;
+              t.generation <- generation;
+              IO.clear ~generation ~reopen:true log.io;
+              Tbl.clear log.mem;
+              hook `After_clear;
+              let log_async = Option.get t.log_async in
+              let append_io = IO.append log.io in
+              Tbl.iter
+                (fun key value ->
+                  Tbl.replace log.mem key value;
+                  Entry.encode' key value append_io)
+                log_async.mem;
+              (* NOTE: It {i may} not be necessary to trigger the
+                 [flush_callback] here. If the instance has been recently
+                 flushed (or [log_async] just reached the [auto_flush_limit]),
+                 we're just moving already-persisted values around. However, we
+                 trigger the callback anyway for simplicity. *)
+              (* `fsync` is necessary, since bindings in `log_async` may have
+                 been explicitely `fsync`ed during the merge, so we need to
+                 maintain their durability. *)
+              IO.flush ~with_fsync:true log.io;
+              IO.clear ~generation:(Int64.succ generation) ~reopen:false
+                log_async.io;
+              (* log_async.mem does not need to be cleared as we are discarding
+                 it. *)
+              t.log_async <- None;
+              rename_lock_duration)
+        in
+        hook `After;
+        (`Completed, rename_lock_duration)
+
   let merge' ?(blocking = false) ?filter ?(hook = fun _ -> ()) ~witness
       ?(force = false) t =
-    let yield () = check_pending_cancel t in
-    let counter = Mtime_clock.counter () in
+    let merge_started = Mtime_clock.counter () in
     let merge_id = merge_counter () in
     let msg = Fmt.strf "merge { id=%d }" merge_id in
     Semaphore.acquire msg t.merge_lock;
-    let merge_lock_wait = Mtime_clock.count counter in
+    let merge_lock_wait = Mtime_clock.count merge_started in
     Log.info (fun l ->
         let pp_forced ppf () = if force then Fmt.string ppf "; force=true" in
         l "[%s] merge started { id=%d%a }" (Filename.basename t.root) merge_id
@@ -603,128 +714,18 @@ struct
        a log, so that the [index] IO doesn't need to trigger the
        [flush_callback]. *)
     flush_instance ~no_async:() ~with_fsync:true t;
-
     let go () =
-      (try hook `Before
-       with exn ->
-         Semaphore.release t.merge_lock;
-         raise exn);
-      let log = Option.get t.log in
-      let generation = Int64.succ t.generation in
-      let log_array =
-        let compare_entry (e : Entry.t) (e' : Entry.t) =
-          compare e.key_hash e'.key_hash
-        in
-        Option.iter
-          (fun f ->
-            Tbl.filter_map_inplace
-              (fun key value -> if f (key, value) then Some value else None)
-              log.mem)
-          filter;
-        let b = Array.make (Tbl.length log.mem) witness in
-        Tbl.fold
-          (fun key value i ->
-            b.(i) <- Entry.v key value;
-            i + 1)
-          log.mem 0
-        |> ignore;
-        Array.fast_sort compare_entry b;
-        b
+      let merge_result, rename_lock_wait =
+        Fun.protect
+          (fun () -> unsafe_perform_merge ~filter ~hook ~witness t)
+          ~finally:(fun () -> Semaphore.release t.merge_lock)
       in
-      let fan_size =
-        match t.index with
-        | None -> Tbl.length log.mem
-        | Some index ->
-            (Int64.to_int (IO.offset index.io) / Entry.encoded_size)
-            + Array.length log_array
-      in
-      let fan_out =
-        Fan.v ~hash_size:K.hash_size ~entry_size:Entry.encoded_size fan_size
-      in
-      let merge =
-        let merge_path = Layout.merge ~root:t.root in
-        IO.v ~fresh:true ~generation
-          ~fan_size:(Int64.of_int (Fan.exported_size fan_out))
-          merge_path
-      in
-      let merge_result : [ `Index_io of IO.t | `Aborted ] =
-        match t.index with
-        | None -> (
-            match yield () with
-            | `Abort -> `Aborted
-            | `Continue ->
-                let io =
-                  IO.v ~fresh:true ~generation ~fan_size:0L
-                    (Layout.data ~root:t.root)
-                in
-                append_remaining_log fan_out log_array 0 merge;
-                `Index_io io)
-        | Some index -> (
-            match
-              merge_with ~hook ~yield ~filter log_array index.io fan_out merge
-            with
-            | `Completed -> `Index_io index.io
-            | `Aborted -> `Aborted)
-      in
-      let cleanup_result, rename_lock_wait =
-        match merge_result with
-        | `Aborted -> (`Aborted, Mtime.Span.zero)
-        | `Index_io io ->
-            let fan_out = Fan.finalize fan_out in
-            let index = { io; fan_out } in
-            IO.set_fanout merge (Fan.export index.fan_out);
-            let rename_lock_wait =
-              let before_rename_lock = Mtime_clock.count counter in
-              Semaphore.with_acquire "merge-rename" t.rename_lock (fun () ->
-                  let after_rename_lock = Mtime_clock.count counter in
-                  IO.rename ~src:merge ~dst:index.io;
-                  t.index <- Some index;
-                  t.generation <- generation;
-                  IO.clear ~generation ~reopen:true log.io;
-                  Tbl.clear log.mem;
-                  (try hook `After_clear
-                   with exn ->
-                     Semaphore.release t.merge_lock;
-                     raise exn);
-                  let log_async = Option.get t.log_async in
-                  let append_io = IO.append log.io in
-                  Tbl.iter
-                    (fun key value ->
-                      Tbl.replace log.mem key value;
-                      Entry.encode' key value append_io)
-                    log_async.mem;
-                  (* NOTE: It {i may} not be necessary to trigger the
-                     [flush_callback] here. If the instance has been recently
-                     flushed (or [log_async] just reached the [auto_flush_limit]),
-                     we're just moving already-persisted values around. However, we
-                     trigger the callback anyway for simplicity. *)
-                  (* `fsync` is necessary, since bindings in `log_async` may have
-                     been explicitely `fsync`ed during the merge, so we need to
-                     maintain their durability. *)
-                  (try IO.flush ~with_fsync:true log.io
-                   with exn ->
-                     Semaphore.release t.merge_lock;
-                     raise exn);
-                  IO.clear ~generation:(Int64.succ generation) ~reopen:false
-                    log_async.io;
-                  (* log_async.mem does not need to be cleared as we are discarding
-                     it. *)
-                  t.log_async <- None;
-                  Mtime.Span.abs_diff after_rename_lock before_rename_lock)
-            in
-            (try hook `After
-             with exn ->
-               Semaphore.release t.merge_lock;
-               raise exn);
-            (`Completed, rename_lock_wait)
-      in
-      let total_duration = Mtime_clock.count counter in
+      let total_duration = Mtime_clock.count merge_started in
       let merge_duration = Mtime.Span.abs_diff total_duration merge_lock_wait in
-      Semaphore.release t.merge_lock;
       Stats.add_merge_duration merge_duration;
       Log.info (fun l ->
           let action =
-            match cleanup_result with
+            match merge_result with
             | `Aborted -> "aborted"
             | `Completed -> "completed"
           in
@@ -734,7 +735,7 @@ struct
             (Filename.basename t.root) action merge_id Mtime.Span.pp
             total_duration Mtime.Span.pp merge_duration Mtime.Span.pp
             merge_lock_wait Mtime.Span.pp rename_lock_wait);
-      cleanup_result
+      merge_result
     in
     if blocking then go () |> Thread.return else Thread.async go
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -138,8 +138,9 @@ struct
     Semaphore.with_acquire "clear" t.merge_lock (fun () ->
         t.pending_cancel <- false;
         t.generation <- Int64.succ t.generation;
-        let log = assert_and_get t.log in
-        IO.clear ~generation:t.generation log.io;
+        let log = Option.get t.log in
+        let hook () = hook `IO_clear in
+        IO.clear ~generation:t.generation ~hook log.io;
         Tbl.clear log.mem;
         may
           (fun l ->

--- a/src/index.ml
+++ b/src/index.ml
@@ -895,6 +895,7 @@ module Private = struct
   module Io_array = Io_array
   module Search = Search
   module Data = Data
+  module Layout = Layout
 
   module Hook = struct
     type 'a t = 'a -> unit

--- a/src/index.ml
+++ b/src/index.ml
@@ -310,8 +310,8 @@ struct
       if readonly then if fresh then raise RO_not_allowed else None
       else
         let io =
-          IO.v ~flush_callback ~fresh ~readonly ~generation:0L ~fan_size:0L
-            log_path
+          IO.v ~flush_callback ~fresh ~generation:0L
+            ~fan_size:0L log_path
         in
         let entries = Int64.div (IO.offset io) entry_sizeL in
         Log.debug (fun l ->
@@ -329,7 +329,7 @@ struct
        there is no need to do it here. *)
     if (not readonly) && IO.exists log_async_path then (
       let io =
-        IO.v ~flush_callback ~fresh ~readonly:false ~generation:0L ~fan_size:0L
+        IO.v ~flush_callback ~fresh ~generation:0L ~fan_size:0L
           log_async_path
       in
       let entries = Int64.div (IO.offset io) entry_sizeL in
@@ -360,8 +360,8 @@ struct
             (* NOTE: No [flush_callback] on the Index IO as we maintain the
                invariant that any bindings it contains were previously persisted
                in either [log] or [log_async]. *)
-            IO.v ?flush_callback:None ~fresh ~readonly ~generation
-              ~fan_size:0L index_path
+            IO.v ?flush_callback:None ~fresh ~generation ~fan_size:0L
+              index_path
           in
           let entries = Int64.div (IO.offset io) entry_sizeL in
           if entries = 0L then None
@@ -580,8 +580,9 @@ struct
     let log_async =
       let io =
         let log_async_path = Layout.log_async ~root:t.root in
-        IO.v ~flush_callback:t.config.flush_callback ~fresh:true ~readonly:false
-          ~generation:(Int64.succ t.generation) ~fan_size:0L log_async_path
+        IO.v ~flush_callback:t.config.flush_callback ~fresh:true
+          ~generation:(Int64.succ t.generation) ~fan_size:0L
+          log_async_path
       in
       let mem = Tbl.create 0 in
       { io; mem }
@@ -630,7 +631,7 @@ struct
       in
       let merge =
         let merge_path = Layout.merge ~root:t.root in
-        IO.v ~fresh:true ~readonly:false ~generation
+        IO.v ~fresh:true ~generation
           ~fan_size:(Int64.of_int (Fan.exported_size fan_out))
           merge_path
       in
@@ -641,7 +642,7 @@ struct
             | `Abort -> `Aborted
             | `Continue ->
                 let io =
-                  IO.v ~fresh:true ~readonly:false ~generation ~fan_size:0L
+                  IO.v ~fresh:true ~generation ~fan_size:0L
                     (Layout.data ~root:t.root)
                 in
                 append_remaining_log fan_out log_array 0 merge;

--- a/src/index.ml
+++ b/src/index.ml
@@ -582,9 +582,6 @@ struct
       - [t.log_async] has been created;
       - [t.merge_lock] is acquired before entry, and released immediately after
         this function returns or raises an exception. *)
-  let compare_entry (e : Entry.t) (e' : Entry.t) =
-    compare e.key_hash e'.key_hash
-
   let unsafe_perform_merge ~witness ~filter ~hook t =
     hook `Before;
     let log = Option.get t.log in
@@ -603,7 +600,7 @@ struct
           i + 1)
         log.mem 0
       |> ignore;
-      Array.fast_sort compare_entry b;
+      Array.fast_sort Entry.compare b;
       b
     in
     let fan_size =

--- a/src/index.ml
+++ b/src/index.ml
@@ -329,8 +329,7 @@ struct
       if readonly then if fresh then raise RO_not_allowed else None
       else
         let io =
-          IO.v ~flush_callback ~fresh ~generation:0L
-            ~fan_size:0L log_path
+          IO.v ~flush_callback ~fresh ~generation:0L ~fan_size:0L log_path
         in
         let entries = Int64.div (IO.offset io) entry_sizeL in
         Log.debug (fun l ->
@@ -348,8 +347,7 @@ struct
        there is no need to do it here. *)
     if (not readonly) && IO.exists log_async_path then (
       let io =
-        IO.v ~flush_callback ~fresh ~generation:0L ~fan_size:0L
-          log_async_path
+        IO.v ~flush_callback ~fresh ~generation:0L ~fan_size:0L log_async_path
       in
       let entries = Int64.div (IO.offset io) entry_sizeL in
       Log.debug (fun l ->
@@ -378,8 +376,7 @@ struct
             (* NOTE: No [flush_callback] on the Index IO as we maintain the
                invariant that any bindings it contains were previously persisted
                in either [log] or [log_async]. *)
-            IO.v ?flush_callback:None ~fresh ~generation ~fan_size:0L
-              index_path
+            IO.v ?flush_callback:None ~fresh ~generation ~fan_size:0L index_path
           in
           let entries = Int64.div (IO.offset io) entry_sizeL in
           if entries = 0L then None
@@ -708,8 +705,7 @@ struct
       let io =
         let log_async_path = Layout.log_async ~root:t.root in
         IO.v ~flush_callback:t.config.flush_callback ~fresh:true
-          ~generation:(Int64.succ t.generation) ~fan_size:0L
-          log_async_path
+          ~generation:(Int64.succ t.generation) ~fan_size:0L log_async_path
       in
       let mem = Tbl.create 0 in
       { io; mem }

--- a/src/index.ml
+++ b/src/index.ml
@@ -213,14 +213,12 @@ struct
     Log.debug (fun l ->
         l "[%s] checking on-disk %s file" (Filename.basename t.root)
           (Filename.basename path));
-    if IO.exists path then (
-      let io =
-        IO.v ~fresh:false ~readonly:true ~generation:0L ~fan_size:0L path
-      in
-      let mem = Tbl.create 0 in
-      iter_io (fun e -> Tbl.replace mem e.key e.value) io;
-      Some { io; mem })
-    else None
+    match IO.v_readonly path with
+    | None -> None
+    | Some io ->
+        let mem = Tbl.create 0 in
+        iter_io (fun e -> Tbl.replace mem e.key e.value) io;
+        Some { io; mem }
 
   let sync_log_entries ?min log =
     let add_log_entry (e : Entry.t) = Tbl.replace log.mem e.key e.value in
@@ -240,14 +238,13 @@ struct
   let sync_index t =
     Option.iter (fun (i : index) -> IO.close i.io) t.index;
     let index_path = Layout.data ~root:t.root in
-    if IO.exists index_path then
-      let io =
-        IO.v ~fresh:false ~readonly:true ~generation:0L ~fan_size:0L index_path
-      in
-      let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-      if IO.offset io = 0L then t.index <- None
-      else t.index <- Some { fan_out; io }
-    else t.index <- None
+    match IO.v_readonly index_path with
+    | None -> t.index <- None
+    | Some io ->
+        let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
+        (* We maintain that [index] is [None] if the file is empty. *)
+        if IO.offset io = 0L then t.index <- None
+        else t.index <- Some { fan_out; io }
 
   let sync_log ?(hook = fun _ -> ()) t =
     Log.debug (fun l ->
@@ -355,27 +352,31 @@ struct
           log;
       IO.close io);
     let index =
-      let index_path = Layout.data ~root in
-      if IO.exists index_path then
-        let io =
-          (* NOTE: No [flush_callback] on the Index IO as we maintain the
-             invariant that any bindings it contains were previously persisted
-             in either [log] or [log_async]. *)
-          IO.v ?flush_callback:None ~fresh ~readonly ~generation ~fan_size:0L
-            index_path
-        in
-        let entries = Int64.div (IO.offset io) entry_sizeL in
-        if entries = 0L then None
+      if readonly then None
+      else
+        let index_path = Layout.data ~root in
+        if IO.exists index_path then
+          let io =
+            (* NOTE: No [flush_callback] on the Index IO as we maintain the
+               invariant that any bindings it contains were previously persisted
+               in either [log] or [log_async]. *)
+            IO.v ?flush_callback:None ~fresh ~readonly ~generation
+              ~fan_size:0L index_path
+          in
+          let entries = Int64.div (IO.offset io) entry_sizeL in
+          if entries = 0L then None
+          else (
+            Log.debug (fun l ->
+                l "[%s] index file detected. Loading %Ld entries"
+                  (Filename.basename root) entries);
+            let fan_out =
+              Fan.import ~hash_size:K.hash_size (IO.get_fanout io)
+            in
+            Some { fan_out; io })
         else (
           Log.debug (fun l ->
-              l "[%s] index file detected. Loading %Ld entries"
-                (Filename.basename root) entries);
-          let fan_out = Fan.import ~hash_size:K.hash_size (IO.get_fanout io) in
-          Some { fan_out; io })
-      else (
-        Log.debug (fun l ->
-            l "[%s] no index file detected." (Filename.basename root));
-        None)
+              l "[%s] no index file detected." (Filename.basename root));
+          None)
     in
     {
       config;

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -363,6 +363,7 @@ module type Index = sig
     module Io_array = Io_array
     module Fan = Fan
     module Data = Data
+    module Layout = Layout
 
     module type S = Private with type 'a hook := 'a Hook.t
 

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -235,7 +235,7 @@ module type Private = sig
       concurrent merge operations, but {i before} blocking on those
       cancellations having completed. *)
 
-  val clear' : hook:[ `Abort_signalled ] hook -> t -> unit
+  val clear' : hook:[ `Abort_signalled | `IO_clear ] hook -> t -> unit
 
   val try_merge_aux :
     ?hook:merge_stages hook -> ?force:bool -> t -> merge_result async

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -253,7 +253,14 @@ module type Private = sig
       [sampling_interval] is not set, no operation is timed. *)
 
   val sync' :
-    ?hook:[ `Before_offset_read | `After_offset_read ] hook -> t -> unit
+    ?hook:
+      [ `Before_offset_read
+      | `After_offset_read
+      | `Reload_log
+      | `Reload_log_async ]
+      hook ->
+    t ->
+    unit
   (** Hooks:
 
       - [`Before_offset_read]: before reading the generation number and the

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -31,6 +31,9 @@ module type S = sig
 
   val close : t -> unit
 
+  val size_header : t -> int
+  (** [size_header t] is [t]'s header size. *)
+
   module Lock : sig
     type t
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -15,7 +15,7 @@ module type S = sig
 
   val read : t -> off:int64 -> len:int -> bytes -> int
 
-  val clear : generation:int64 -> t -> unit
+  val clear : generation:int64 -> ?hook:(unit -> unit) -> t -> unit
 
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -15,7 +15,8 @@ module type S = sig
 
   val read : t -> off:int64 -> len:int -> bytes -> int
 
-  val clear : generation:int64 -> ?hook:(unit -> unit) -> t -> unit
+  val clear :
+    generation:int64 -> ?hook:(unit -> unit) -> reopen:bool -> t -> unit
 
   val flush : ?no_callback:unit -> ?with_fsync:bool -> t -> unit
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -9,7 +9,7 @@ module type S = sig
     string ->
     t
 
-  val v_readonly : string -> t option
+  val v_readonly : string -> (t, [ `No_file_on_disk ]) result
 
   val offset : t -> int64
 

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -3,7 +3,6 @@ module type S = sig
 
   val v :
     ?flush_callback:(unit -> unit) ->
-    readonly:bool ->
     fresh:bool ->
     generation:int64 ->
     fan_size:int64 ->

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -10,6 +10,8 @@ module type S = sig
     string ->
     t
 
+  val v_readonly : string -> t option
+
   val offset : t -> int64
 
   val read : t -> off:int64 -> len:int -> bytes -> int

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -167,13 +167,12 @@ module IO : Index.IO = struct
       flush_callback;
     }
 
-  let v ?flush_callback ~readonly ~fresh ~generation ~fan_size file =
-    let v = v_instance ?flush_callback ~readonly file in
-    let mode = Unix.(if readonly then O_RDONLY else O_RDWR) in
+  let v ?flush_callback ~fresh ~generation ~fan_size file =
+    let v = v_instance ?flush_callback ~readonly:false file in
     mkdir (Filename.dirname file);
     match Sys.file_exists file with
     | false ->
-        let x = Unix.openfile file Unix.[ O_CREAT; O_CLOEXEC; mode ] 0o644 in
+        let x = Unix.openfile file Unix.[ O_CREAT; O_CLOEXEC; O_RDWR ] 0o644 in
         let raw = Raw.v x in
         Raw.Offset.set raw 0L;
         Raw.Fan.set_size raw fan_size;
@@ -181,11 +180,9 @@ module IO : Index.IO = struct
         Raw.Generation.set raw generation;
         v ~fan_size ~offset:0L raw
     | true ->
-        let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; mode ] 0o644 in
+        let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; O_RDWR ] 0o644 in
         let raw = Raw.v x in
-        if readonly && fresh then
-          Fmt.failwith "IO.v: cannot reset a readonly file"
-        else if fresh then (
+        if fresh then (
           Raw.Offset.set raw 0L;
           Raw.Fan.set_size raw fan_size;
           Raw.Version.set raw current_version;

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -150,13 +150,14 @@ module IO : Index.IO = struct
     Raw.Fan.set raw "";
     raw
 
-  let clear ~generation t =
+  let clear ~generation ?(hook = fun () -> ()) t =
     t.offset <- 0L;
     t.flushed <- t.header;
     Buffer.clear t.buf;
     (* the generation is updated before calling clear. *)
     Header.set t { offset = t.offset; generation };
     Raw.close t.raw;
+    hook ();
     (* delete the file. *)
     Unix.unlink t.file;
     (* and re-open a fresh instance *)

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -221,6 +221,8 @@ module IO : Index.IO = struct
 
   let size { raw; _ } = (Raw.fstat raw).st_size
 
+  let size_header t = t.header |> Int64.to_int
+
   module Lock = struct
     type t = { path : string; fd : Unix.file_descr }
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -210,11 +210,11 @@ module IO : Index.IO = struct
           version current_version;
       let offset = Raw.Offset.get raw in
       let fan_size = Raw.Fan.get_size raw in
-      Some (v ~fan_size ~offset raw)
+      Ok (v ~fan_size ~offset raw)
     with
     | Unix.Unix_error (Unix.ENOENT, _, _) ->
         (* The readonly instance cannot open a non existing file. *)
-        None
+        Error `No_file_on_disk
     | e -> raise e
 
   let exists = Sys.file_exists

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -148,6 +148,7 @@ module IO : Index.IO = struct
     let header = { Raw.Header.offset; version; generation } in
     Raw.Header.set raw header;
     Raw.Fan.set raw "";
+    Raw.fsync raw;
     raw
 
   let clear ~generation ?(hook = fun () -> ()) ~reopen t =
@@ -197,23 +198,23 @@ module IO : Index.IO = struct
   let v ?flush_callback ~fresh ~generation ~fan_size file =
     let v = v_instance ?flush_callback ~readonly:false file in
     mkdir (Filename.dirname file);
+    let header =
+      { Raw.Header.offset = 0L; version = current_version; generation }
+    in
     match Sys.file_exists file with
     | false ->
         let x = Unix.openfile file Unix.[ O_CREAT; O_CLOEXEC; O_RDWR ] 0o644 in
         let raw = Raw.v x in
-        Raw.Offset.set raw 0L;
+        Raw.Header.set raw header;
         Raw.Fan.set_size raw fan_size;
-        Raw.Version.set raw current_version;
-        Raw.Generation.set raw generation;
         v ~fan_size ~offset:0L raw
     | true ->
         let x = Unix.openfile file Unix.[ O_EXCL; O_CLOEXEC; O_RDWR ] 0o644 in
         let raw = Raw.v x in
         if fresh then (
-          Raw.Offset.set raw 0L;
+          Raw.Header.set raw header;
           Raw.Fan.set_size raw fan_size;
-          Raw.Version.set raw current_version;
-          Raw.Generation.set raw generation;
+          Raw.fsync raw;
           v ~fan_size ~offset:0L raw)
         else
           let version = Raw.Version.get raw in

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -142,7 +142,7 @@ module IO : Index.IO = struct
     in
     (aux [@tailcall]) dirname (fun () -> ())
 
-  let raw ~flags ~version ~offset ~generation file =
+  let raw_file ~flags ~version ~offset ~generation file =
     let x = Unix.openfile file flags 0o644 in
     let raw = Raw.v x in
     let header = { Raw.Header.offset; version; generation } in
@@ -154,17 +154,24 @@ module IO : Index.IO = struct
     t.offset <- 0L;
     t.flushed <- t.header;
     Buffer.clear t.buf;
-    (* Remove the file current file. This allows a fresh file to be
-       created, before writing the new generation in the temporary file. *)
     let old = t.raw in
-    Unix.unlink t.file;
-    (* Open a fresh file. *)
-    if reopen then
+
+    if reopen then (
+      (* Open a fresh file and rename it to ensure atomicity:
+         concurrent readers should never see the file disapearing. *)
+      let tmp_file = t.file ^ "_tmp" in
       t.raw <-
-        raw ~version:current_version ~generation ~offset:0L
+        raw_file ~version:current_version ~generation ~offset:0L
           ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
-          t.file;
+          tmp_file;
+      Unix.rename tmp_file t.file)
+    else
+      (* Remove the file current file. This allows a fresh file to be
+         created, before writing the new generation in the old file. *)
+      Unix.unlink t.file;
+
     hook ();
+
     (* Set new generation in the old file. *)
     Raw.Header.set old
       { Raw.Header.offset = 0L; generation; version = current_version };

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -150,30 +150,25 @@ module IO : Index.IO = struct
     Raw.Fan.set raw "";
     raw
 
-  let clear ~generation ?(hook = fun () -> ()) t =
+  let clear ~generation ?(hook = fun () -> ()) ~reopen t =
     t.offset <- 0L;
     t.flushed <- t.header;
     Buffer.clear t.buf;
-    let tmp = t.file ^ "_tmp" in
-    Raw.close t.raw;
-    (* Rename file into a temporary file. This allows a fresh file to be
+    (* Remove the file current file. This allows a fresh file to be
        created, before writing the new generation in the temporary file. *)
-    Unix.rename t.file tmp;
-    hook ();
+    let old = t.raw in
+    Unix.unlink t.file;
     (* Open a fresh file. *)
-    t.raw <-
-      raw ~version:current_version ~generation ~offset:0L
-        ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
-        t.file;
-    (* Set new generation in the temporary file. *)
-    let tmp_fd =
-      raw ~version:current_version ~generation ~offset:0L
-        ~flags:Unix.[ O_RDWR; O_CLOEXEC ]
-        tmp
-    in
-    (* Close and remove temporary file. *)
-    Raw.close tmp_fd;
-    Unix.unlink tmp
+    if reopen then
+      t.raw <-
+        raw ~version:current_version ~generation ~offset:0L
+          ~flags:Unix.[ O_CREAT; O_RDWR; O_CLOEXEC ]
+          t.file;
+    hook ();
+    (* Set new generation in the old file. *)
+    Raw.Header.set old
+      { Raw.Header.offset = 0L; generation; version = current_version };
+    Raw.close old
 
   let () = assert (String.length current_version = 8)
 

--- a/test/cli/stat.t/run.t
+++ b/test/cli/stat.t/run.t
@@ -27,11 +27,6 @@ Running `stat` on an index after 10 merges:
         "offset": 3680,
         "generation": 9
       },
-      "log_async": {
-        "size": "32.0 B",
-        "offset": 0,
-        "generation": 10
-      },
       "lock": "<PID>"
     }
   }

--- a/test/cli/stat.t/run.t
+++ b/test/cli/stat.t/run.t
@@ -23,7 +23,7 @@ Running `stat` on an index after 10 merges:
         "generation": 9
       },
       "log": {
-        "size": "3.9 KiB",
+        "size": "3.6 KiB",
         "offset": 3680,
         "generation": 9
       },

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -38,6 +38,12 @@ let random_char () = char_of_int (33 + Random.int 94)
 
 let random_string () = String.init String_size.length (fun _i -> random_char ())
 
+module Default = struct
+  let log_size = 4
+
+  let size = 103
+end
+
 module Key = struct
   include Index.Key.String_fixed (String_size)
 
@@ -124,7 +130,7 @@ struct
 
   let ignore (_ : t) = ()
 
-  let empty_index ?(log_size = 4) ?flush_callback ?throttle () =
+  let empty_index ?(log_size = Default.log_size) ?flush_callback ?throttle () =
     let name = fresh_name "empty_index" in
     let cache = Index.empty_cache () in
     let rw =
@@ -141,8 +147,8 @@ struct
     in
     { rw; tbl; clone; close_all = (fun () -> !close_all ()) }
 
-  let full_index ?(size = 103) ?(log_size = 4) ?(flush_callback = fun () -> ())
-      ?throttle () =
+  let full_index ?(size = Default.size) ?(log_size = Default.log_size)
+      ?(flush_callback = fun () -> ()) ?throttle () =
     let f =
       (* Disable [flush_callback] while adding initial entries *)
       ref (fun () -> ())

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -5,6 +5,12 @@ val report : unit -> unit
 
 module Log : Logs.LOG
 
+module Default : sig
+  val log_size : int
+
+  val size : int
+end
+
 (** Simple key/value modules with String type and a random constructor *)
 module Key : sig
   include Index.Key.S with type t = string

--- a/test/unix/force_merge.ml
+++ b/test/unix/force_merge.ml
@@ -367,7 +367,9 @@ let test_non_blocking_clear () =
     | _ -> ()
   in
   let clear_hook =
-    Hook.v @@ function `Abort_signalled -> Semaphore.release merge
+    Hook.v @@ function
+    | `Abort_signalled -> Semaphore.release merge
+    | `IO_clear -> ()
   in
   add_bindings rw;
   let thread = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
@@ -394,7 +396,9 @@ let test_abort_merge ~abort_merge () =
     | `Before -> ()
   in
   let abort_hook =
-    Hook.v @@ function `Abort_signalled -> Semaphore.release merge
+    Hook.v @@ function
+    | `Abort_signalled -> Semaphore.release merge
+    | `IO_clear -> ()
   in
   let t = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
   Semaphore.acquire merge_started;

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -29,7 +29,7 @@ module IOArray = Index.Private.Io_array.Make (IO) (Entry)
 let entry = Alcotest.(pair string string)
 
 let fresh_io name =
-  IO.v ~readonly:false ~fresh:true ~generation:0L ~fan_size:0L (root // name)
+  IO.v ~fresh:true ~generation:0L ~fan_size:0L (root // name)
 
 (* Append a random sequence of [size] keys to an IO instance and return
    a pair of an IOArray and an equivalent in-memory array. *)

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -28,8 +28,7 @@ module IOArray = Index.Private.Io_array.Make (IO) (Entry)
 
 let entry = Alcotest.(pair string string)
 
-let fresh_io name =
-  IO.v ~fresh:true ~generation:0L ~fan_size:0L (root // name)
+let fresh_io name = IO.v ~fresh:true ~generation:0L ~fan_size:0L (root // name)
 
 (* Append a random sequence of [size] keys to an IO instance and return
    a pair of an IOArray and an equivalent in-memory array. *)

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -554,6 +554,46 @@ module Readonly = struct
     Semaphore.release sync;
     Index.check_binding ro k1 v1
 
+  let reload_log_async () =
+    let* Context.{ rw; clone; _ } = Context.with_empty_index () in
+    let ro = clone ~readonly:true () in
+    let reload_log = ref 0 in
+    let reload_log_async = ref 0 in
+    let merge = Semaphore.make false in
+    let sync = Semaphore.make false in
+    let merge_hook =
+      I.Private.Hook.v @@ function
+      | `Before ->
+          Semaphore.release sync;
+          Semaphore.acquire merge
+      | `After_clear -> Semaphore.release sync
+      | _ -> ()
+    in
+    let sync_hook =
+      I.Private.Hook.v (function
+        | `Reload_log -> reload_log := succ !reload_log
+        | `Reload_log_async -> reload_log_async := succ !reload_log_async
+        | _ -> ())
+    in
+    let k1, v1 = (Key.v (), Value.v ()) in
+    let k2, v2 = (Key.v (), Value.v ()) in
+    Index.replace rw k1 v1;
+    Index.flush rw;
+    let t = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
+    Index.replace rw k2 v2;
+    Index.flush rw;
+    Semaphore.acquire sync;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Index.sync' ~hook:sync_hook ro;
+    Semaphore.release merge;
+    Index.check_binding ro k1 v1;
+    Index.check_binding ro k2 v2;
+    Alcotest.(check int) "reloadings of log per merge" 0 !reload_log;
+    Alcotest.(check int) "reloadings of log async per merge" 1 !reload_log_async;
+    Index.await t |> check_completed
+
   let tests =
     [
       ("add", `Quick, readonly);
@@ -579,6 +619,7 @@ module Readonly = struct
       ( "race between sync and end of merge",
         `Quick,
         readonly_sync_and_merge_clear );
+      ("reload log and log async", `Quick, reload_log_async);
     ]
 end
 

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -516,6 +516,39 @@ module Readonly = struct
     Index.check_binding ro k2 v2;
     Index.check_binding ro k3 v3
 
+  let readonly_sync_and_merge_clear () =
+    let* Context.{ clone; rw; _ } = Context.with_empty_index () in
+    let ro = clone ~readonly:true () in
+    let merge = Semaphore.make false and sync = Semaphore.make false in
+    let merge_hook =
+      I.Private.Hook.v @@ function
+      | `Before ->
+          Semaphore.release sync;
+          Semaphore.acquire merge
+      | `After_clear -> Semaphore.release sync
+      | _ -> ()
+    in
+    let sync_hook =
+      I.Private.Hook.v @@ function
+      | `After_offset_read ->
+          Semaphore.release merge;
+          Semaphore.acquire sync
+      | _ -> ()
+    in
+    let gen i = (String.make Key.encoded_size i, Value.v ()) in
+    let k1, v1 = gen '1' in
+    let k2, v2 = gen '2' in
+
+    Index.replace rw k1 v1;
+    Index.flush rw;
+    let thread = Index.try_merge_aux ~force:true ~hook:merge_hook rw in
+    Index.replace rw k2 v2;
+    Semaphore.acquire sync;
+    Index.sync' ~hook:sync_hook ro;
+    Index.await thread |> check_completed;
+    Semaphore.release sync;
+    Index.check_binding ro k1 v1
+
   let tests =
     [
       ("add", `Quick, readonly);
@@ -538,6 +571,9 @@ module Readonly = struct
       ("readonly open after clear", `Quick, readonly_open_after_clear);
       ("race between sync and merge", `Quick, readonly_sync_and_merge);
       ("race between sync and clear", `Quick, readonly_io_clear);
+      ( "race between sync and end of merge",
+        `Quick,
+        readonly_sync_and_merge_clear );
     ]
 end
 

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -298,6 +298,23 @@ module Readonly = struct
     check_no_index_entry rw k;
     check_no_index_entry ro k
 
+  (* If sync is called right after the generation is set, and before the old
+     file is removed, the readonly instance reopens the old file. It does not
+     try to reopen the file until the next generation change occurs. *)
+  let readonly_io_clear () =
+    let* Context.{ rw; clone; _ } = Context.with_full_index () in
+    let ro = clone ~readonly:true () in
+    let hook =
+      Hook.v @@ function `IO_clear -> Index.sync ro | `Abort_signalled -> ()
+    in
+    Index.clear' ~hook rw;
+    let k, v = (Key.v (), Value.v ()) in
+    Index.replace rw k v;
+    Index.flush rw;
+    Index.sync ro;
+    Index.check_binding rw k v;
+    Index.check_binding ro k v
+
   let hashtbl_pick tbl =
     match Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl [] with
     | h :: _ -> h
@@ -520,6 +537,7 @@ module Readonly = struct
         readonly_add_index_after_clear );
       ("readonly open after clear", `Quick, readonly_open_after_clear);
       ("race between sync and merge", `Quick, readonly_sync_and_merge);
+      ("race between sync and clear", `Quick, readonly_io_clear);
     ]
 end
 


### PR DESCRIPTION
The 1.3.1 release contains:
- fix for potential race(s) between clear (e.g. merge) and sync
- fix for potential race(s) between syncs
- improved update latency for sync just after a merge
- performance improvements for syncs happening at the same time as blocking merges
- proper resource cleanup when a merge fails
- unlink unused files after a merge/clear
- a minor crash consistency fix
- reduced allocations during merge