### PR TITLE
Refactor use of monotonic time in Index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@
 - `clear` removes the files on disks and opens new ones containing only the
   header. (#288)
 
+- `Index.Make` now requires an implementation of a monotonic time source.
+  (#321)
+
+- The `Index.Make` functor now takes a single `Platform` argument containing all
+  system dependencies (i.e. `IO`, `Clock`, `Semaphore` and `Thread`).  (#321)
+
 ## Added
 
 - Added benchmarks that replay a trace of index operations. (#300)

--- a/bench/common.ml
+++ b/bench/common.ml
@@ -14,31 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let reporter ?(prefix = "") () =
-  let report src level ~over k msgf =
-    let k _ =
-      over ();
-      k ()
-    in
-    let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
-    let with_stamp h _tags k fmt =
-      let dt = Unix.gettimeofday () in
-      Fmt.kpf k ppf
-        ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
-        prefix dt Logs_fmt.pp_header (level, h)
-        Fmt.(styled `Magenta string)
-        (Logs.Src.name src)
-    in
-    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k fmt
-  in
-  { Logs.report }
-
-let setup_log style_renderer level =
-  Fmt_tty.setup_std_outputs ?style_renderer ();
-  Logs.set_level level;
-  Logs.set_reporter (reporter ());
-  ()
-
 module Seq = struct
   include Seq
 

--- a/bench/common.ml
+++ b/bench/common.ml
@@ -23,10 +23,10 @@ module Seq = struct
 end
 
 let with_timer f =
-  let t0 = Sys.time () in
+  let started = Mtime_clock.counter () in
   let a = f () in
-  let t1 = Sys.time () -. t0 in
-  (t1, a)
+  let duration = Mtime_clock.count started in
+  (a, duration)
 
 let with_progress_bar ~sampling_interval ~message ~n ~unit =
   let bar =

--- a/bench/common.ml
+++ b/bench/common.ml
@@ -59,6 +59,5 @@ module FSHelper = struct
     if Sys.file_exists root then (
       let cmd = Printf.sprintf "rm -rf %s" root in
       Logs.info (fun l -> l "exec: %s" cmd);
-      let _ = Sys.command cmd in
-      ())
+      ignore (Sys.command cmd : int))
 end

--- a/bench/dune
+++ b/bench/dune
@@ -27,7 +27,7 @@
  (preprocess
   (pps ppx_repr))
  (libraries index index.unix unix cmdliner logs repr ppx_repr common
-   tezos-context-hash optint fmt rusage mtime))
+   tezos-context-hash optint fmt rusage mtime mtime.clock.os))
 
 ;; Require the above executables to compile during tests
 

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,8 @@
+(library
+ (name common)
+ (modules common)
+ (libraries progress progress.unix logs fmt mtime mtime.clock.os))
+
 (executable
  (public_name bench)
  (modules bench)
@@ -5,12 +10,7 @@
  (preprocess
   (pps ppx_repr ppx_deriving_yojson))
  (libraries index index.unix cmdliner metrics metrics-unix yojson fmt re
-   stdlib-shims))
-
-(library
- (name common)
- (modules common)
- (libraries progress progress.unix logs fmt))
+   stdlib-shims common mtime))
 
 (alias
  (name bench)
@@ -27,7 +27,7 @@
  (preprocess
   (pps ppx_repr))
  (libraries index index.unix unix cmdliner logs repr ppx_repr common
-   tezos-context-hash optint fmt rusage))
+   tezos-context-hash optint fmt rusage mtime))
 
 ;; Require the above executables to compile during tests
 

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -37,6 +37,7 @@ module Encoding = struct
   module Int63 = struct
     include Optint.Int63
 
+    (* TODO: upstream this to Repr *)
     let t : t Repr.t =
       let open Repr in
       (map int64) of_int64 to_int64
@@ -129,6 +130,8 @@ module type S = sig
   val v : string -> t
   val close : t -> unit
 end
+
+module Index_lib = Index
 
 module Index = struct
   module Index =
@@ -233,10 +236,9 @@ let trace_data_file =
   in
   Arg.(required @@ pos 0 (some string) None doc)
 
-let setup_log =
-  Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
-
-let main_term = Term.(const main $ setup_log $ nb_ops $ trace_data_file)
+let main_term =
+  Term.(
+    const main $ Index_lib.Private.Logs.setup_term () $ nb_ops $ trace_data_file)
 
 let () =
   let man =

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -65,7 +65,7 @@ module Encoding = struct
 end
 
 let decoded_seq_of_encoded_chan_with_prefixes :
-    'a Repr.ty -> in_channel -> 'a Seq.t =
+      'a. 'a Repr.ty -> in_channel -> 'a Seq.t =
  fun repr channel ->
   let decode_bin = Repr.decode_bin repr |> Repr.unstage in
   let decode_prefix = Repr.(decode_bin int32 |> unstage) in
@@ -107,10 +107,10 @@ module Trace = struct
 end
 
 module Benchmark = struct
-  type result = { time : float; size : int }
+  type result = { time : Mtime.Span.t; size : int }
 
   let run config f =
-    let time, res = with_timer f in
+    let res, time = with_timer f in
     let size = FSHelper.get_size config.root in
     ({ time; size }, res)
 
@@ -120,8 +120,8 @@ module Benchmark = struct
     usage.maxrss / 1024L / 1024L
 
   let pp_results ppf result =
-    Format.fprintf ppf "Total time: %f; Size on disk: %d M; Maxrss: %Ld"
-      result.time result.size (get_maxrss ())
+    Format.fprintf ppf "Total time: %a; Size on disk: %d M; Maxrss: %Ld"
+      Mtime.Span.pp result.time result.size (get_maxrss ())
 end
 
 module type S = sig

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -178,10 +178,9 @@ struct
               | Find (k, b) ->
                   let k = key_to_hash k in
                   let b' =
-                    try
-                      let _ = Store.find store k in
-                      true
-                    with Not_found -> false
+                    match Store.find store k with
+                    | (_ : Store.value) -> true
+                    | exception Not_found -> false
                   in
                   if b <> b' then
                     Fmt.failwith "Operation find %a expected %b got %b"
@@ -220,7 +219,7 @@ let main () nb_ops trace_data_file =
   FSHelper.rm_dir root;
   let config = { trace_data_file; root; nb_ops } in
   let results = Bench.run_read_trace config in
-  Logs.app (fun l -> l "%a@." (fun ppf f -> f ppf) results)
+  Logs.app (fun l -> l "%t@." results)
 
 open Cmdliner
 

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -237,7 +237,10 @@ let trace_data_file =
 
 let main_term =
   Term.(
-    const main $ Index_lib.Private.Logs.setup_term () $ nb_ops $ trace_data_file)
+    const main
+    $ Index_lib.Private.Logs.setup_term (module Mtime_clock)
+    $ nb_ops
+    $ trace_data_file)
 
 let () =
   let man =

--- a/index-bench.opam
+++ b/index-bench.opam
@@ -19,9 +19,10 @@ depends: [
   "yojson"
   "ppx_repr"
   "tezos-context-hash"
-  "logs" {>= "0.7.0" & with-test}
+  "mtime"
+  "logs" {>= "0.7.0"}
   "optint" {>= "0.1.0" & with-test}
-  "progress" {>= "0.1.1" & with-test}
+  "progress" {>= "0.1.1"}
   "repr" {>= "0.2.1" & with-test}
   "rusage" {>= "1.0.0" & with-test}
 ]

--- a/src/checks.ml
+++ b/src/checks.ml
@@ -1,7 +1,8 @@
 include Checks_intf
 open! Import
 
-module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
+module Make (K : Data.Key) (V : Data.Value) (Platform : Platform_args) = struct
+  open Platform
   module Entry = Data.Entry.Make (K) (V)
 
   module IO = struct
@@ -177,10 +178,10 @@ module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) = struct
       Term.(
         eval_choice default
           [
-            ( Stat.term $ Logs.setup_term ~reporter (),
+            ( Stat.term $ Logs.setup_term ~reporter (module Clock),
               Term.info ~doc:"Print high-level statistics about the store."
                 "stat" );
-            ( Integrity_check.term $ Logs.setup_term ~reporter (),
+            ( Integrity_check.term $ Logs.setup_term ~reporter (module Clock),
               Term.info
                 ~doc:"Search the store for integrity faults and corruption."
                 "integrity-check" );

--- a/src/checks_intf.ml
+++ b/src/checks_intf.ml
@@ -25,10 +25,16 @@ module type S = sig
       checks. *)
 end
 
+module type Platform_args = sig
+  module IO : Io.S
+  module Clock : Platform.CLOCK
+end
+
 module type Checks = sig
   type nonrec empty = empty
 
   module type S = S
+  module type Platform_args = Platform_args
 
-  module Make (K : Data.Key) (V : Data.Value) (IO : Io.S) : S
+  module Make (K : Data.Key) (V : Data.Value) (_ : Platform_args) : S
 end

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name index)
  (name index)
- (libraries logs fmt stdlib-shims mtime mtime.clock.os cmdliner logs.fmt
-   logs.cli fmt.cli fmt.tty jsonm progress progress.unix repr ppx_repr optint)
+ (libraries logs fmt stdlib-shims mtime cmdliner logs.fmt logs.cli fmt.cli
+   fmt.tty jsonm progress progress.unix repr ppx_repr optint)
  (preprocess
   (pps ppx_repr)))

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,3 +1,42 @@
 module Int63 = Optint.Int63
 
 type int63 = Int63.t
+
+module Logs = struct
+  let default_reporter ?(prefix = "") () =
+    let report src level ~over k msgf =
+      let k _ =
+        over ();
+        k ()
+      in
+      let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
+      let with_stamp h _tags k fmt =
+        let dt = Unix.gettimeofday () in
+        Fmt.kpf k ppf
+          ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
+          prefix dt Logs_fmt.pp_header (level, h)
+          Fmt.(styled `Magenta string)
+          (Logs.Src.name src)
+      in
+      msgf @@ fun ?header ?tags fmt -> with_stamp header tags k fmt
+    in
+    { Logs.report }
+
+  let setup ?(reporter = default_reporter ()) ?style_renderer ?level () =
+    Fmt_tty.setup_std_outputs ?style_renderer ();
+    Logs.set_level level;
+    Logs.set_reporter reporter;
+    ()
+
+  open Cmdliner
+
+  let ( let+ ) t f = Term.(const f $ t)
+  let ( and+ ) a b = Term.(const (fun x y -> (x, y)) $ a $ b)
+
+  let setup_term ?reporter () =
+    let+ style_renderer = Fmt_cli.style_renderer ()
+    and+ level = Logs_cli.level () in
+    setup ?reporter ?style_renderer ?level ()
+
+  include Logs
+end

--- a/src/import.ml
+++ b/src/import.ml
@@ -3,7 +3,8 @@ module Int63 = Optint.Int63
 type int63 = Int63.t
 
 module Logs = struct
-  let default_reporter ?(prefix = "") () =
+  let default_reporter (type c) ?(prefix = "")
+      (module Clock : Platform.CLOCK with type counter = c) (counter : c) =
     let report src level ~over k msgf =
       let k _ =
         over ();
@@ -11,7 +12,7 @@ module Logs = struct
       in
       let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
       let with_stamp h _tags k fmt =
-        let dt = Unix.gettimeofday () in
+        let dt = Mtime.Span.to_us (Clock.count counter) in
         Fmt.kpf k ppf
           ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
           prefix dt Logs_fmt.pp_header (level, h)
@@ -22,7 +23,13 @@ module Logs = struct
     in
     { Logs.report }
 
-  let setup ?(reporter = default_reporter ()) ?style_renderer ?level () =
+  let setup ?reporter ?style_renderer ?level (module Clock : Platform.CLOCK) =
+    let start_time = Clock.counter () in
+    let reporter =
+      match reporter with
+      | Some x -> x
+      | None -> default_reporter (module Clock) start_time
+    in
     Fmt_tty.setup_std_outputs ?style_renderer ();
     Logs.set_level level;
     Logs.set_reporter reporter;
@@ -33,10 +40,10 @@ module Logs = struct
   let ( let+ ) t f = Term.(const f $ t)
   let ( and+ ) a b = Term.(const (fun x y -> (x, y)) $ a $ b)
 
-  let setup_term ?reporter () =
+  let setup_term ?reporter (module Clock : Platform.CLOCK) =
     let+ style_renderer = Fmt_cli.style_renderer ()
     and+ level = Logs_cli.level () in
-    setup ?reporter ?style_renderer ?level ()
+    setup ?reporter ?style_renderer ?level (module Clock : Platform.CLOCK)
 
   include Logs
 end

--- a/src/index.ml
+++ b/src/index.ml
@@ -939,7 +939,7 @@ struct
 
   let replace_with_timer ?sampling_interval t key value =
     match sampling_interval with
-    | None -> replace t key value (* XXX(craigfe): why not log duration here? *)
+    | None -> replace t key value
     | Some sampling_interval ->
         Stats.start_replace ();
         replace t key value;
@@ -1013,7 +1013,7 @@ struct
 
   let close = close' ~hook:(fun _ -> ())
 
-  module Checks = Checks.Make (K) (V) (IO)
+  module Checks = Checks.Make (K) (V) (Platform)
 end
 
 module Cache = Cache

--- a/src/index.ml
+++ b/src/index.ml
@@ -42,11 +42,11 @@ exception Closed
 module Make_private
     (K : Key)
     (V : Value)
-    (IO : Io.S)
-    (Semaphore : SEMAPHORE)
-    (Thread : THREAD)
+    (Platform : PLATFORM)
     (Cache : Cache.S) =
 struct
+  open Platform
+
   type 'a async = 'a Thread.t
 
   let await = Thread.await

--- a/src/index.ml
+++ b/src/index.ml
@@ -68,6 +68,11 @@ struct
 
   let entry_sizeL = Int63.of_int Entry.encoded_size
 
+  module Stats = struct
+    include Stats.Make (Clock)
+    include Stats
+  end
+
   module Tbl = Hashtbl.Make (K)
 
   module IO = struct
@@ -747,10 +752,10 @@ struct
         let fan_out = Fan.finalize fan_out in
         let index = { io; fan_out } in
         IO.set_fanout merge (Fan.export index.fan_out);
-        let before_rename_lock = Mtime_clock.counter () in
+        let before_rename_lock = Clock.counter () in
         let rename_lock_duration =
           Semaphore.with_acquire "merge-rename" t.rename_lock (fun () ->
-              let rename_lock_duration = Mtime_clock.count before_rename_lock in
+              let rename_lock_duration = Clock.count before_rename_lock in
               IO.rename ~src:merge ~dst:index.io;
               t.index <- Some index;
               t.generation <- generation;
@@ -785,11 +790,11 @@ struct
 
   let merge' ?(blocking = false) ?filter ?(hook = fun _ -> ()) ~witness
       ?(force = false) t =
-    let merge_started = Mtime_clock.counter () in
+    let merge_started = Clock.counter () in
     let merge_id = merge_counter () in
     let msg = Fmt.strf "merge { id=%d }" merge_id in
     Semaphore.acquire msg t.merge_lock;
-    let merge_lock_wait = Mtime_clock.count merge_started in
+    let merge_lock_wait = Clock.count merge_started in
     Log.info (fun l ->
         let pp_forced ppf () = if force then Fmt.string ppf "; force=true" in
         l "[%s] merge started { id=%d%a }" (Filename.basename t.root) merge_id
@@ -818,7 +823,7 @@ struct
           (fun () -> unsafe_perform_merge ~filter ~hook ~witness t)
           ~finally:(fun () -> Semaphore.release t.merge_lock)
       in
-      let total_duration = Mtime_clock.count merge_started in
+      let total_duration = Clock.count merge_started in
       let merge_duration = Mtime.Span.abs_diff total_duration merge_lock_wait in
       Stats.add_merge_duration merge_duration;
       Log.info (fun l ->
@@ -933,11 +938,12 @@ struct
     ignore (replace' ?hook:None ?overcommit t key value : _ async option)
 
   let replace_with_timer ?sampling_interval t key value =
-    if sampling_interval <> None then Stats.start_replace ();
-    replace t key value;
     match sampling_interval with
-    | None -> ()
-    | Some sampling_interval -> Stats.end_replace ~sampling_interval
+    | None -> replace t key value (* XXX(craigfe): why not log duration here? *)
+    | Some sampling_interval ->
+        Stats.start_replace ();
+        replace t key value;
+        Stats.end_replace ~sampling_interval
 
   (** {1 Filter} *)
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -1022,6 +1022,7 @@ module Private = struct
   module Search = Search
   module Data = Data
   module Layout = Layout
+  module Logs = Logs
 
   module Hook = struct
     type 'a t = 'a -> unit

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -374,6 +374,17 @@ module type Index = sig
     module Data = Data
     module Layout = Layout
 
+    module Logs : sig
+      val setup :
+        ?reporter:Logs.reporter ->
+        ?style_renderer:Fmt.style_renderer ->
+        ?level:Logs.level ->
+        unit ->
+        unit
+
+      val setup_term : ?reporter:Logs.reporter -> unit -> unit Cmdliner.Term.t
+    end
+
     module type S = Private with type 'a hook := 'a Hook.t
 
     module Make

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -81,6 +81,7 @@ module type PLATFORM = sig
   module IO : IO
   module Semaphore : SEMAPHORE
   module Thread : THREAD
+  module Clock : Io.CLOCK
 end
 
 module type S = sig

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -377,10 +377,13 @@ module type Index = sig
         ?reporter:Logs.reporter ->
         ?style_renderer:Fmt.style_renderer ->
         ?level:Logs.level ->
-        unit ->
+        (module Platform.CLOCK) ->
         unit
 
-      val setup_term : ?reporter:Logs.reporter -> unit -> unit Cmdliner.Term.t
+      val setup_term :
+        ?reporter:Logs.reporter ->
+        (module Platform.CLOCK) ->
+        unit Cmdliner.Term.t
     end
 
     module type S = Private with type 'a hook := 'a Hook.t

--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -1,5 +1,15 @@
 open! Import
 
+module type CLOCK = sig
+  (** A monotonic time source. See {!Mtime_clock} for an OS-dependent
+      implementation. *)
+
+  type counter
+
+  val counter : unit -> counter
+  val count : counter -> Mtime.Span.t
+end
+
 module type S = sig
   type t
 
@@ -60,6 +70,7 @@ module type S = sig
 end
 
 module type Io = sig
+  module type CLOCK = CLOCK
   module type S = S
 
   module Extend (S : S) : sig

--- a/src/platform.ml
+++ b/src/platform.ml
@@ -1,0 +1,9 @@
+module type CLOCK = sig
+  (** A monotonic time source. See {!Mtime_clock} for an OS-dependent
+      implementation. *)
+
+  type counter
+
+  val counter : unit -> counter
+  val count : counter -> Mtime.span
+end

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -28,6 +28,7 @@ let fresh_stats () =
   }
 
 let stats = fresh_stats ()
+let get () = stats
 
 let reset_stats () =
   stats.bytes_read <- 0;
@@ -41,7 +42,6 @@ let reset_stats () =
   stats.nb_sync <- 0;
   stats.time_sync <- 0.0
 
-let get () = stats
 let incr_bytes_read n = stats.bytes_read <- stats.bytes_read + n
 let incr_bytes_written n = stats.bytes_written <- stats.bytes_written + n
 let incr_nb_reads () = stats.nb_reads <- succ stats.nb_reads
@@ -58,29 +58,31 @@ let add_write n =
   incr_bytes_written n;
   incr_nb_writes ()
 
-let replace_timer = ref (Mtime_clock.counter ())
-let nb_replace = ref 0
+module Make (Clock : Io.CLOCK) = struct
+  let replace_timer = ref (Clock.counter ())
+  let nb_replace = ref 0
 
-let start_replace () =
-  if !nb_replace = 0 then replace_timer := Mtime_clock.counter ()
+  let start_replace () =
+    if !nb_replace = 0 then replace_timer := Clock.counter ()
 
-let end_replace ~sampling_interval =
-  nb_replace := !nb_replace + 1;
-  if !nb_replace = sampling_interval then (
-    let span = Mtime_clock.count !replace_timer in
-    let average = Mtime.Span.to_us span /. float_of_int !nb_replace in
-    stats.replace_durations <- average :: stats.replace_durations;
-    replace_timer := Mtime_clock.counter ();
-    nb_replace := 0)
+  let end_replace ~sampling_interval =
+    nb_replace := !nb_replace + 1;
+    if !nb_replace = sampling_interval then (
+      let span = Clock.count !replace_timer in
+      let average = Mtime.Span.to_us span /. float_of_int !nb_replace in
+      stats.replace_durations <- average :: stats.replace_durations;
+      replace_timer := Clock.counter ();
+      nb_replace := 0)
 
-let sync_with_timer f =
-  let timer = Mtime_clock.counter () in
-  f ();
-  let span = Mtime_clock.count timer in
-  stats.time_sync <- Mtime.Span.to_us span
+  let sync_with_timer f =
+    let timer = Clock.counter () in
+    f ();
+    let span = Clock.count timer in
+    stats.time_sync <- Mtime.Span.to_us span
 
-let drop_head l = if List.length l >= 10 then List.tl l else l
+  let drop_head l = if List.length l >= 10 then List.tl l else l
 
-let add_merge_duration span =
-  let span = Mtime.Span.to_us span in
-  stats.merge_durations <- drop_head stats.merge_durations @ [ span ]
+  let add_merge_duration span =
+    let span = Mtime.Span.to_us span in
+    stats.merge_durations <- drop_head stats.merge_durations @ [ span ]
+end

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -27,14 +27,17 @@ type t = {
       [sampling_interval] specified when calling [end_replace].
     - [time_sync] is the duration of the latest call to sync. *)
 
-val reset_stats : unit -> unit
 val get : unit -> t
+val reset_stats : unit -> unit
 val add_read : int -> unit
 val add_write : int -> unit
 val incr_nb_merge : unit -> unit
 val incr_nb_replace : unit -> unit
 val incr_nb_sync : unit -> unit
-val start_replace : unit -> unit
-val end_replace : sampling_interval:int -> unit
-val sync_with_timer : (unit -> unit) -> unit
-val add_merge_duration : Mtime.Span.t -> unit
+
+module Make (_ : Io.CLOCK) : sig
+  val start_replace : unit -> unit
+  val end_replace : sampling_interval:int -> unit
+  val sync_with_timer : (unit -> unit) -> unit
+  val add_merge_duration : Mtime.Span.t -> unit
+end

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -378,6 +378,7 @@ module Platform = struct
   module IO = IO
   module Semaphore = Semaphore
   module Thread = Thread
+  module Clock = Mtime_clock
 end
 
 module Make (K : Index.Key.S) (V : Index.Value.S) =

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -374,8 +374,14 @@ module Thread = struct
         | None -> assert false)
 end
 
+module Platform = struct
+  module IO = IO
+  module Semaphore = Semaphore
+  module Thread = Thread
+end
+
 module Make (K : Index.Key.S) (V : Index.Value.S) =
-  Index.Make (K) (V) (IO) (Semaphore) (Thread)
+  Index.Make (K) (V) (Platform)
 
 module Syscalls = Syscalls
 
@@ -384,5 +390,5 @@ module Private = struct
   module Raw = Raw
 
   module Make (K : Index.Key.S) (V : Index.Value.S) =
-    Index.Private.Make (K) (V) (IO) (Semaphore) (Thread)
+    Index.Private.Make (K) (V) (Platform)
 end

--- a/test/cli/stat.t/run.t
+++ b/test/cli/stat.t/run.t
@@ -2,7 +2,6 @@ No files are shown when running `stat` in a non-existent directory:
 
   $ ../index_fsck.exe stat ../data/non-existent-store
   >> Getting statistics for store: `../data/non-existent-store'
-  
   {
     "entry_size": "40.0 B",
     "files": {}
@@ -13,7 +12,6 @@ Running `stat` on an index after 10 merges:
   $ ../index_fsck.exe stat ../data/random > log.txt 2>&1
   $ sed -Ee 's/"lock": "[0-9]+"/"lock": "<PID>"/g' log.txt
   >> Getting statistics for store: `../data/random'
-  
   {
     "entry_size": "40.0 B",
     "files": {

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -1,32 +1,11 @@
 let ( >> ) f g x = g (f x)
-
-let reporter ?(prefix = "") () =
-  let report src level ~over k msgf =
-    let k _ =
-      over ();
-      k ()
-    in
-    let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
-    let with_stamp h _tags k fmt =
-      let dt = Unix.gettimeofday () in
-      Fmt.kpf k ppf
-        ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
-        prefix dt
-        Fmt.(styled `Magenta string)
-        (Logs.Src.name src) Logs_fmt.pp_header (level, h)
-    in
-    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k fmt
-  in
-  { Logs.report }
-
 let src = Logs.Src.create "test/unix" ~doc:"Index_unix tests"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let report () =
   Logs_threaded.enable ();
-  Logs.set_level (Some Logs.Debug);
-  Logs.set_reporter (reporter ())
+  Index.Private.Logs.setup ~level:Logs.Debug ()
 
 module String_size = struct
   let length = 20

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -5,7 +5,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let report () =
   Logs_threaded.enable ();
-  Index.Private.Logs.setup ~level:Logs.Debug ()
+  Index.Private.Logs.setup ~level:Logs.Debug (module Mtime_clock)
 
 module String_size = struct
   let length = 20

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -2,4 +2,4 @@
  (names main force_merge io_array)
  (package index)
  (libraries index index.unix alcotest fmt logs logs.fmt re stdlib-shims
-   threads.posix repr semaphore-compat optint))
+   threads.posix repr semaphore-compat optint mtime.clock.os))


### PR DESCRIPTION
- avoid using `Sys.time` to measure durations;
- avoid dependency on `mtime.clock.os` in Index core by functorising over a time source.

... and does some minor refactoring to extract `Logs` boilerplate and cleanup.

Fix https://github.com/mirage/index/issues/314.