### PR TITLE
Release the prefetch warning threshold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Changed
 
+- Release overly defensive warnings occuring when pre-fetching the disk. (#322)
+
 - Specialise `IO.v` to create read-only or read-write instances. (#291)
 
 - Optimised the in-memory representation of index handles, resulting in a

--- a/src/io_array.ml
+++ b/src/io_array.ml
@@ -79,8 +79,8 @@ module Make (IO : Io.S) (Elt : ELT) :
     (* The prefetched area should not exceed 4096 in most cases, thanks to the
        fan out. However, if the hash function is not well distributed, some
        exceptions might happen where the prefetched area actually exceeds 4096.
-       As long as this excess is reasonable (x2), we still want to prefetch. *)
-    2 * 4096
+       As long as this excess is reasonable (x8), we still want to prefetch. *)
+    8 * 4096
 
   let buf = Bytes.create max_buffer_size
 


### PR DESCRIPTION
The current setting is probably a bit too defensive, as unevenly distributed keys happens quite often in practice.