### PR TITLE
Fan warning and bench updated with a log reporter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 
 - Added benchmarks that replay a trace of index operations. (#300)
 
+- Log reporter for the benches
+
 # 1.3.0 (2021-01-05)
 
 ## Added

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ doc:
 	dune build @doc
 
 bench:
-	@dune exec -- ./bench/bench.exe --json --minimal --nb-exec 3
+	@dune exec -- ./bench/bench.exe --json --minimal --nb-exec 3 --verbosity quiet

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -149,6 +149,8 @@ let bindings_pool = ref [||]
 let absent_bindings_pool = ref [||]
 let sorted_bindings_pool = ref [||]
 
+module Index_lib = Index
+
 module Index = struct
   module Index =
     Index_unix.Private.Make (Context.Key) (Context.Value) (Index.Cache.Noop)
@@ -639,7 +641,8 @@ let minimal_flag =
 let cmd =
   let doc = "Run all the benchmarks." in
   ( Term.(
-      const run
+      const (fun () -> run)
+      $ Index_lib.Private.Logs.setup_term (module Mtime_clock)
       $ name_filter
       $ data_dir
       $ output

--- a/bench/dune
+++ b/bench/dune
@@ -10,7 +10,7 @@
  (preprocess
   (pps ppx_repr ppx_deriving_yojson))
  (libraries index index.unix cmdliner metrics metrics-unix yojson fmt re
-   stdlib-shims common mtime))
+   stdlib-shims common mtime mtime.clock.os))
 
 (alias
  (name bench)

--- a/bench/replay.ml
+++ b/bench/replay.ml
@@ -212,7 +212,7 @@ end
 
 module Bench = Bench_suite (Index)
 
-let main () nb_ops trace_data_file =
+let main nb_ops trace_data_file =
   Printexc.record_backtrace true;
   Random.self_init ();
   let root = "_bench_replay" in
@@ -237,7 +237,7 @@ let trace_data_file =
 
 let main_term =
   Term.(
-    const main
+    const (fun () -> main)
     $ Index_lib.Private.Logs.setup_term (module Mtime_clock)
     $ nb_ops
     $ trace_data_file)


### PR DESCRIPTION
Fan warning is invoked when the fan-out is double in size

The log reporter is quiet by default when using `make bench` and shall
be invoked with `--verbosity {error | warning | info | debug}`