### PR TITLE
Avoid using an intermediate scratch buffer in the merge

### DIFF
--- a/src/io_intf.ml
+++ b/src/io_intf.ml
@@ -35,6 +35,7 @@ module type S = sig
   val get_fanout_size : t -> int63
   val rename : src:t -> dst:t -> unit
   val append : t -> string -> unit
+  val append_substring : t -> string -> off:int -> len:int -> unit
   val close : t -> unit
 
   val size_header : t -> int

--- a/src/unix/buffer.ml
+++ b/src/unix/buffer.ml
@@ -41,10 +41,10 @@ let resize b more =
   Bytes.blit b.buffer 0 new_buffer 0 b.position;
   b.buffer <- new_buffer
 
-let add_substring b s offset len =
+let add_substring b s ~off ~len =
   let new_position = b.position + len in
   if new_position > Bytes.length b.buffer then resize b len;
-  unsafe_blit_string s offset b.buffer b.position len;
+  unsafe_blit_string s off b.buffer b.position len;
   b.position <- new_position
 
-let add_string b s = add_substring b s 0 (String.length s)
+let add_string b s = add_substring b s ~off:0 ~len:(String.length s)

--- a/src/unix/buffer.mli
+++ b/src/unix/buffer.mli
@@ -30,6 +30,10 @@ val clear : t -> unit
 (** [clear t] clears the data contained in [t]. It does not reset the buffer to
     its initial size. *)
 
+val add_substring : t -> string -> off:int -> len:int -> unit
+(** [add_substring t s ~off ~len] appends the substring
+    [s.(off) .. s.(off + len - 1)] at the end of [t], resizing [t] if necessary. *)
+
 val add_string : t -> string -> unit
 (** [add_string t s] appends [s] at the end of [t], resizing [t] if necessary. *)
 

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -75,12 +75,14 @@ module IO : Index.IO = struct
 
   let auto_flush_limit = Int63.of_int 1_000_000
 
-  let append t buf =
+  let append_substring t buf ~off ~len =
     if t.readonly then raise RO_not_allowed;
-    Buffer.add_string t.buf buf;
-    let len = Int63.of_int (String.length buf) in
+    Buffer.add_substring t.buf buf ~off ~len;
+    let len = Int63.of_int len in
     t.offset <- t.offset ++ len;
     if t.offset -- t.flushed > auto_flush_limit then flush t
+
+  let append t buf = append_substring t buf ~off:0 ~len:(String.length buf)
 
   let read t ~off ~len buf =
     if not t.readonly then assert (t.header ++ off <= t.flushed);


### PR DESCRIPTION
The merge process loads entries from the old data file into a buffer before writing them out to the new one. Previously, individual entries were then copied to a second buffer before writing, but this isn't necessary: the IO can simply read substrings from the first one directly.