### PR TITLE
Constrain progress version

### DIFF
--- a/index-bench.opam
+++ b/index-bench.opam
@@ -22,7 +22,7 @@ depends: [
   "mtime"
   "logs" {>= "0.7.0"}
   "optint" {>= "0.1.0" & with-test}
-  "progress" {>= "0.1.1"}
+  "progress" {= "0.1.1"}
   "repr" {>= "0.2.1" & with-test}
   "rusage" {>= "1.0.0" & with-test}
 ]

--- a/index.opam
+++ b/index.opam
@@ -28,7 +28,7 @@ depends: [
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
   "cmdliner"
-  "progress" {>= "0.1.1"}
+  "progress" {= "0.1.1"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"
   "stdlib-shims"


### PR DESCRIPTION
Constrain the version of progress to `0.1.1` until https://github.com/CraigFe/progress/issues/12 is fixed, and until we upgrade index's code

Cc @CraigFe 