### PR TITLE
Avoid flaky usage of [@tailcall]

### DIFF
--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -139,9 +139,9 @@ module IO : Index.Platform.IO = struct
       if Sys.file_exists dir && Sys.is_directory dir then k ()
       else (
         if Sys.file_exists dir then safe Unix.unlink dir;
-        (aux [@tailcall]) (Filename.dirname dir) @@ fun () ->
-        protect (Unix.mkdir dir) 0o755;
-        k ())
+        (aux [@tailcall]) (Filename.dirname dir) (fun () ->
+            protect (Unix.mkdir dir) 0o755;
+            k ()))
     in
     (aux [@tailcall]) dirname (fun () -> ())
 


### PR DESCRIPTION
As of `4.13.0~alpha`, function applications on the left-hand-side of an application of `( @@ )` are rejected as not tailcalls.