### PR TITLE
Add an fsync after flushing the log file on startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
   continue to run and will need to recover from the crash before doing a new
   merge. This fixes a critical issue which might cause data loss (#339)
 
+- Make sure that no entries can disappear for read-only instances during
+  log_async recovery (#338)
+
 # 1.4.0 (2021-06-16)
 
 ## Fixed

--- a/src/index.ml
+++ b/src/index.ml
@@ -478,7 +478,9 @@ struct
             Tbl.replace log.mem e.key e.value;
             Entry.encode e append_io)
           log_async;
-        IO.flush log.io;
+        (* Force fsync here so that persisted entries in log_async
+           continue to persist in log. *)
+        IO.flush ~with_fsync:true log.io;
         IO.clear ~generation ~reopen:false log_async
 
   let v_no_cache ?(flush_callback = fun () -> ()) ~throttle ~fresh ~readonly


### PR DESCRIPTION
On startup, we transfer entries from log_async to log. Make sure to call fsync here so that persisted entries in log_async continue to be persisted in log.

