### PR TITLE
Prepare 1.3.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 1.3.3 (2021-07-27)
+
+## Fixed
+
+- Attempt to recover from `log_async` invariant violations during an explicit
+  sync operation, rather than failing immediately. (#329)
+
 # 1.3.2 (2021-06-16)
 
 ## Fixed
@@ -25,9 +32,6 @@
 
 - Added fsync after `Index.clear` to signal more quickly to read-only instances
   than something has changed in the file (#308)
-
-- Attempt to recover from `log_async` invariant violations during an explicit
-  sync operation, rather than failing immediately. (#329)
 
 ## Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@
 - Added fsync after `Index.clear` to signal more quickly to read-only instances
   than something has changed in the file (#308)
 
+- Attempt to recover from `log_async` invariant violations during an explicit
+  sync operation, rather than failing immediately. (#329)
+
 ## Changed
 
 - Specialise `IO.v` to create read-only or read-write instances. (#291)


### PR DESCRIPTION
This backports https://github.com/mirage/index/pull/329 to the 1.3.x series of Index releases.

Corresponding opam-repository PR: https://github.com/ocaml/opam-repository/pull/19137.