### PR TITLE
Reduce the memory usage of the write-ahead log

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 - Fix stats recording in `Raw.unsafe_write` (#351)
 
+## Changed
+
+- Changed the implementation of the write-ahead log to significantly reduce its
+  memory usage (at the cost of some additional disk IO). (#355)
+
 # 1.4.1 (2021-07-16)
 
 ## Fixed

--- a/src/data.ml
+++ b/src/data.ml
@@ -52,6 +52,7 @@ module Entry = struct
 
     val v : key -> value -> t
     val encoded_size : int
+    val encoded_sizeL : int63
     val decode : string -> int -> t
     val decode_key : string -> int -> key * int
     val decode_value : string -> int -> value
@@ -67,6 +68,7 @@ module Entry = struct
 
     let v key value = { key; key_hash = K.hash key; value }
     let encoded_size = K.encoded_size + V.encoded_size
+    let encoded_sizeL = Int63.of_int encoded_size
 
     let decode string off =
       let key = K.decode string off in

--- a/src/index.ml
+++ b/src/index.ml
@@ -871,6 +871,11 @@ struct
     if blocking then go () |> Thread.return else Thread.async go
 
   let is_empty t =
+    (* A read-only instance may have not yet loaded the [log], if no explicit
+       [sync] has yet occurred, leaving some ambiguity as to whether the index
+       is strictly "empty". For now, we only need this internal function for
+       read-write instances, so we dodge the question .*)
+    assert (not t.config.readonly);
     match t.log with
     | None -> true
     | Some log -> Option.is_none t.index && Log_file.cardinal log = 0

--- a/src/index.ml
+++ b/src/index.ml
@@ -203,13 +203,12 @@ struct
 
   (** Extract [log] and [log_async] for (private) tests. *)
 
-  let to_list t =
-    Log_file.to_sorted_seq t
-    |> Seq.map (fun (e : Entry.t) -> (e.key, e.value))
-    |> List.of_seq
-
   let log_file_to_list msg log =
-    let x = to_list log in
+    let x =
+      Log_file.to_sorted_seq log
+      |> Seq.map (fun (e : Entry.t) -> (e.key, e.value))
+      |> List.of_seq
+    in
     let y = ref [] in
     IO.iter
       (fun _ (e : Entry.t) -> y := (e.key, e.value) :: !y)

--- a/src/log_file.ml
+++ b/src/log_file.ml
@@ -96,6 +96,11 @@ module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) = struct
     (* Scale the number of hashset buckets. *)
     t.bucket_count_log2 <- t.bucket_count_log2 + 1;
     let new_bucket_count = 1 lsl t.bucket_count_log2 in
+    if new_bucket_count > Sys.max_array_length then
+      Fmt.failwith
+        "Log_file.resize: can't construct a hashset with %d buckets \
+         (Sys.max_array_length = %d)"
+        new_bucket_count Sys.max_array_length;
     let new_hashset = Array.make new_bucket_count Small_list.empty in
     ArrayLabels.iteri t.hashset ~f:(fun i bucket ->
         (* The bindings in this bucket will be split into two new buckets, using

--- a/src/log_file.ml
+++ b/src/log_file.ml
@@ -180,7 +180,7 @@ module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) = struct
         hashset;
         bucket_count_log2;
         scratch_buf = Bytes.create Entry.encoded_size;
-        cardinal = 0;
+        cardinal;
       }
     in
     IO.iter_keys (fun offset key -> replace_memory t key offset) io;

--- a/src/log_file.ml
+++ b/src/log_file.ml
@@ -1,0 +1,181 @@
+(*
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+
+module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) = struct
+  module Entry = Data.Entry.Make (Key) (Value)
+
+  module IO = struct
+    include Io.Extend (IO)
+
+    let iter_keys ?min f =
+      let page_size = Int63.(mul Entry.encoded_sizeL (of_int 1_000)) in
+      iter ~page_size ?min (fun ~off ~buf ~buf_off ->
+          let key, _ = Entry.decode_key buf buf_off in
+          f off key;
+          Entry.encoded_size)
+  end
+
+  type t = {
+    io : IO.t;  (** The disk file handler *)
+    append_io : string -> unit;  (** Pre-allocated [IO.append io] closure *)
+    mutable hashset : int63 Small_list.t Array.t;
+        (** Hashset of offsets of entries in [io], keyed by the hash of the key
+            stored at each offset. *)
+    mutable scratch_buf : bytes;
+    mutable cardinal : int;
+  }
+
+  let io t = t.io
+  let cardinal t = t.cardinal
+
+  let clear_memory t =
+    t.hashset <- [| Small_list.empty |];
+    t.cardinal <- 0
+
+  let clear ~generation ?hook ~reopen t =
+    IO.clear ~generation ?hook ~reopen t.io;
+    clear_memory t
+
+  let close t =
+    IO.close t.io;
+    clear_memory t
+
+  let flush ?no_callback ~with_fsync t = IO.flush ?no_callback ~with_fsync t.io
+
+  let to_seq t =
+    Array.to_seq t.hashset
+    |> Seq.flat_map (fun bucket ->
+           Small_list.to_list bucket
+           |> List.to_seq
+           |> Seq.map (fun off ->
+                  let n =
+                    IO.read t.io ~off ~len:Entry.encoded_size t.scratch_buf
+                  in
+                  assert (n = Entry.encoded_size);
+                  let entry =
+                    Entry.decode (Bytes.unsafe_to_string t.scratch_buf) 0
+                  in
+                  (entry.key, entry.value)))
+
+  let key_of_offset t off =
+    let r = IO.read t.io ~off ~len:Key.encoded_size t.scratch_buf in
+    assert (r = Key.encoded_size);
+    fst (Entry.decode_key (Bytes.unsafe_to_string t.scratch_buf) 0)
+
+  let entry_of_offset t off =
+    let r = IO.read t.io ~off ~len:Entry.encoded_size t.scratch_buf in
+    assert (r = Entry.encoded_size);
+    Entry.decode (Bytes.unsafe_to_string t.scratch_buf) 0
+
+  let iter_hashset t ~f =
+    ArrayLabels.iter t.hashset ~f:(fun bucket -> Small_list.iter bucket ~f)
+
+  let resize t =
+    (* Scale the number of hashset buckets. *)
+    let new_bucket_count = (2 * Array.length t.hashset) + 1 in
+    let new_hashset = Array.make new_bucket_count Small_list.empty in
+    iter_hashset t ~f:(fun offset ->
+        let key = key_of_offset t offset in
+        let new_index = Key.hash key mod new_bucket_count in
+        new_hashset.(new_index) <-
+          Small_list.cons offset new_hashset.(new_index));
+    t.hashset <- new_hashset
+
+  (** Replace implementation that only updates in-memory state (and doesn't
+      write the binding to disk). *)
+  let replace_memory t key offset =
+    if t.cardinal / 2 > Array.length t.hashset then resize t;
+    let elt_idx = Key.hash key mod Array.length t.hashset in
+    let bucket = t.hashset.(elt_idx) in
+    let bucket =
+      let key_found = ref false in
+      let bucket' =
+        Small_list.map bucket ~f:(fun offset' ->
+            if !key_found then
+              (* We ensure there's at most one binding for a given key *)
+              offset'
+            else
+              let key' = key_of_offset t offset' in
+              match Key.equal key key' with
+              | false -> offset'
+              | true ->
+                  (* New binding for this key *)
+                  key_found := true;
+                  offset)
+      in
+      match !key_found with
+      | true ->
+          (* We're replacing an existing value. No need to change [cardinal]. *)
+          bucket'
+      | false ->
+          (* The existing bucket doesn't contain this key. *)
+          t.cardinal <- t.cardinal + 1;
+          Small_list.cons offset bucket
+    in
+    t.hashset.(elt_idx) <- bucket
+
+  let replace t key value =
+    let offset = IO.offset t.io in
+    Entry.encode' key value t.append_io;
+    replace_memory t key offset
+
+  let sync_entries ~min t =
+    IO.iter_keys ~min (fun offset key -> replace_memory t key offset) t.io
+
+  let reload t =
+    clear_memory t;
+    sync_entries ~min:Int63.zero t
+
+  let create io =
+    let cardinal = Int63.(to_int_exn (IO.offset io / Entry.encoded_sizeL)) in
+    let bucket_count = max 1 (cardinal / 2) in
+    let hashset = Array.make bucket_count Small_list.empty in
+    let t =
+      {
+        io;
+        append_io = IO.append io;
+        hashset;
+        scratch_buf = Bytes.create Entry.encoded_size;
+        cardinal = 0;
+      }
+    in
+    IO.iter_keys (fun offset key -> replace_memory t key offset) io;
+    t
+
+  let find t key =
+    let elt_idx = Key.hash key mod Array.length t.hashset in
+    let bucket = t.hashset.(elt_idx) in
+    Small_list.find_map bucket ~f:(fun offset ->
+        (* We expect the keys to match most of the time, so we decode the
+           value at the same time. *)
+        let entry = entry_of_offset t offset in
+        match Key.equal key entry.key with
+        | false -> None
+        | true -> Some entry.value)
+    |> function
+    | None -> raise Not_found
+    | Some x -> x
+
+  let fold t ~f ~init =
+    ArrayLabels.fold_left t.hashset ~init ~f:(fun acc bucket ->
+        Small_list.fold_left bucket ~init:acc ~f:(fun acc offset ->
+            let entry = entry_of_offset t offset in
+            f acc entry))
+
+  let iter t ~f = iter_hashset t ~f:(fun offset -> f (entry_of_offset t offset))
+end

--- a/src/log_file.mli
+++ b/src/log_file.mli
@@ -1,0 +1,60 @@
+(*
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open! Import
+
+module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) : sig
+  module Entry : Data.Entry.S with type key := Key.t and type value := Value.t
+
+  type t
+  type key := Key.t
+  type value := Value.t
+
+  val create : IO.t -> t
+  val close : t -> unit
+
+  (** {2 Hashtable API} *)
+
+  val cardinal : t -> int
+  val find : t -> key -> value
+  val replace : t -> key -> value -> unit
+  val iter : t -> f:(Entry.t -> unit) -> unit
+  val fold : t -> f:('acc -> Entry.t -> 'acc) -> init:'acc -> 'acc
+  val to_seq : t -> (key * value) Seq.t
+  val filteri_inplace : t -> f:(key -> value -> bool) -> unit
+
+  (** {2 Low-level API} *)
+
+  val io : t -> IO.t
+  (** [io t] is [t]'s underlying IO handle. Any updates to the file will not be
+      reflected in the in-memory mirror of its state. *)
+
+  val sync_entries : min:int63 -> t -> unit
+  (** [sync_entries ~min t] loads the entries from [log]'s IO into memory,
+      starting from offset [min]. *)
+
+  val flush : ?no_callback:unit -> with_fsync:bool -> t -> unit
+  (** [flush t] is [IO.flush (io t)]. *)
+
+  val reload : t -> unit
+  (** [reload t] clears [t]'s in-memory state and reloads all bindings from the
+      underlying IO hande. *)
+
+  val clear :
+    generation:int63 -> ?hook:(unit -> unit) -> reopen:bool -> t -> unit
+  (** [clear t] clears both [t]'s in-memory state and its underlying IO handle.
+      The flags are passed to [IO.clear]. *)
+end

--- a/src/log_file.mli
+++ b/src/log_file.mli
@@ -24,6 +24,11 @@ module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) : sig
   type value := Value.t
 
   val create : IO.t -> t
+  (** [create io] constructs a write-ahead log from an IO handle referencing an
+      unordered sequence of (binary encoded) [key * value] bindings. The
+      bindings are read into memory, and any subsequent {!replace} operations
+      are reflected on disk. *)
+
   val close : t -> unit
 
   (** {2 Hashtable API} *)

--- a/src/log_file.mli
+++ b/src/log_file.mli
@@ -33,8 +33,11 @@ module Make (IO : Io.S) (Key : Data.Key) (Value : Data.Value) : sig
   val replace : t -> key -> value -> unit
   val iter : t -> f:(Entry.t -> unit) -> unit
   val fold : t -> f:('acc -> Entry.t -> 'acc) -> init:'acc -> 'acc
-  val to_seq : t -> (key * value) Seq.t
-  val filteri_inplace : t -> f:(key -> value -> bool) -> unit
+
+  val to_sorted_seq : t -> Entry.t Seq.t
+  (** [to_sorted_seq t] is the sequence of all entries in [t], sorted by
+      [Entry.compare]. Modifying [t] while consuming the sequence results in
+      undefined behaviour. *)
 
   (** {2 Low-level API} *)
 

--- a/src/small_list.ml
+++ b/src/small_list.ml
@@ -150,6 +150,26 @@ let to_list = function
   | Tuple6 (a, b, c, d, e, f) -> [ a; b; c; d; e; f ]
   | Many (a, b, c, d, e, f, g, l) -> a :: b :: c :: d :: e :: f :: g :: l
 
+let to_array = function
+  | Tuple0 -> [||]
+  | Tuple1 a -> [| a |]
+  | Tuple2 (a, b) -> [| a; b |]
+  | Tuple3 (a, b, c) -> [| a; b; c |]
+  | Tuple4 (a, b, c, d) -> [| a; b; c; d |]
+  | Tuple5 (a, b, c, d, e) -> [| a; b; c; d; e |]
+  | Tuple6 (a, b, c, d, e, f) -> [| a; b; c; d; e; f |]
+  | Many (a, b, c, d, e, f, g, l) ->
+      let len = 7 + List.length l in
+      let arr = Array.make len a in
+      arr.(1) <- b;
+      arr.(2) <- c;
+      arr.(3) <- d;
+      arr.(4) <- e;
+      arr.(5) <- f;
+      arr.(6) <- g;
+      List.iteri (fun i elt -> arr.(i + 7) <- elt) l;
+      arr
+
 let of_list = function
   | [] -> Tuple0
   | [ a ] -> Tuple1 a

--- a/src/small_list.ml
+++ b/src/small_list.ml
@@ -1,0 +1,172 @@
+(*
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type 'a t =
+  | Tuple0
+  | Tuple1 of 'a
+  | Tuple2 of 'a * 'a
+  | Tuple3 of 'a * 'a * 'a
+  | Tuple4 of 'a * 'a * 'a * 'a
+  | Tuple5 of 'a * 'a * 'a * 'a * 'a
+  | Tuple6 of 'a * 'a * 'a * 'a * 'a * 'a
+  | Many of 'a * 'a * 'a * 'a * 'a * 'a * 'a * 'a list
+
+let empty = Tuple0
+
+let cons x = function
+  | Tuple0 -> Tuple1 x
+  | Tuple1 a -> Tuple2 (x, a)
+  | Tuple2 (a, b) -> Tuple3 (x, a, b)
+  | Tuple3 (a, b, c) -> Tuple4 (x, a, b, c)
+  | Tuple4 (a, b, c, d) -> Tuple5 (x, a, b, c, d)
+  | Tuple5 (a, b, c, d, e) -> Tuple6 (x, a, b, c, d, e)
+  | Tuple6 (a, b, c, d, e, f) -> Many (x, a, b, c, d, e, f, [])
+  | Many (a, b, c, d, e, f, g, l) -> Many (x, a, b, c, d, e, f, g :: l)
+
+let map ~f:fn = function
+  | Tuple0 -> Tuple0
+  | Tuple1 a -> Tuple1 (fn a)
+  | Tuple2 (a, b) -> Tuple2 (fn a, fn b)
+  | Tuple3 (a, b, c) -> Tuple3 (fn a, fn b, fn c)
+  | Tuple4 (a, b, c, d) -> Tuple4 (fn a, fn b, fn c, fn d)
+  | Tuple5 (a, b, c, d, e) -> Tuple5 (fn a, fn b, fn c, fn d, fn e)
+  | Tuple6 (a, b, c, d, e, f) -> Tuple6 (fn a, fn b, fn c, fn d, fn e, fn f)
+  | Many (a, b, c, d, e, f, g, l) ->
+      Many (fn a, fn b, fn c, fn d, fn e, fn f, fn g, List.map fn l)
+
+let iter ~f:fn = function
+  | Tuple0 -> ()
+  | Tuple1 a -> fn a
+  | Tuple2 (a, b) ->
+      fn a;
+      fn b
+  | Tuple3 (a, b, c) ->
+      fn a;
+      fn b;
+      fn c
+  | Tuple4 (a, b, c, d) ->
+      fn a;
+      fn b;
+      fn c;
+      fn d
+  | Tuple5 (a, b, c, d, e) ->
+      fn a;
+      fn b;
+      fn c;
+      fn d;
+      fn e
+  | Tuple6 (a, b, c, d, e, f) ->
+      fn a;
+      fn b;
+      fn c;
+      fn d;
+      fn e;
+      fn f
+  | Many (a, b, c, d, e, f, g, l) ->
+      fn a;
+      fn b;
+      fn c;
+      fn d;
+      fn e;
+      fn f;
+      fn g;
+      List.iter fn l
+
+let exists ~f:fn = function
+  | Tuple0 -> false
+  | Tuple1 a -> fn a
+  | Tuple2 (a, b) -> fn a || fn b
+  | Tuple3 (a, b, c) -> fn a || fn b || fn c
+  | Tuple4 (a, b, c, d) -> fn a || fn b || fn c || fn d
+  | Tuple5 (a, b, c, d, e) -> fn a || fn b || fn c || fn d || fn e
+  | Tuple6 (a, b, c, d, e, f) -> fn a || fn b || fn c || fn d || fn e || fn f
+  | Many (a, b, c, d, e, f, g, l) ->
+      fn a || fn b || fn c || fn d || fn e || fn f || fn g || List.exists fn l
+
+(* TODO(4.10): use [Stdlib.List.find_map] instead. *)
+let rec list_find_map f = function
+  | [] -> None
+  | x :: l -> (
+      match f x with Some _ as result -> result | None -> list_find_map f l)
+
+let[@ocamlformat "disable"] find_map ~f:fn = function
+  | Tuple0 -> raise Not_found
+  | Tuple1 a -> fn a
+  | Tuple2 (a, b) -> (
+      match fn a with Some _ as r -> r | None ->
+        fn b)
+  | Tuple3 (a, b, c) -> (
+      match fn a with Some _ as r -> r | None ->
+      match fn b with Some _ as r -> r | None ->
+        fn c)
+  | Tuple4 (a, b, c, d) -> (
+      match fn a with Some _ as r -> r | None ->
+      match fn b with Some _ as r -> r | None ->
+      match fn c with Some _ as r -> r | None ->
+        fn d)
+  | Tuple5 (a, b, c, d, e) -> (
+      match fn a with Some _ as r -> r | None ->
+      match fn b with Some _ as r -> r | None ->
+      match fn c with Some _ as r -> r | None ->
+      match fn d with Some _ as r -> r | None ->
+        fn e)
+  | Tuple6 (a, b, c, d, e, f) -> (
+      match fn a with Some _ as r -> r | None ->
+      match fn b with Some _ as r -> r | None ->
+      match fn c with Some _ as r -> r | None ->
+      match fn d with Some _ as r -> r | None ->
+      match fn e with Some _ as r -> r | None ->
+        fn f)
+  | Many (a, b, c, d, e, f, g, l) -> (
+      match fn a with Some _ as r -> r | None ->
+      match fn b with Some _ as r -> r | None ->
+      match fn c with Some _ as r -> r | None ->
+      match fn d with Some _ as r -> r | None ->
+      match fn e with Some _ as r -> r | None ->
+      match fn f with Some _ as r -> r | None ->
+      match fn g with Some _ as r -> r | None ->
+        list_find_map fn l)
+
+let to_list = function
+  | Tuple0 -> []
+  | Tuple1 a -> [ a ]
+  | Tuple2 (a, b) -> [ a; b ]
+  | Tuple3 (a, b, c) -> [ a; b; c ]
+  | Tuple4 (a, b, c, d) -> [ a; b; c; d ]
+  | Tuple5 (a, b, c, d, e) -> [ a; b; c; d; e ]
+  | Tuple6 (a, b, c, d, e, f) -> [ a; b; c; d; e; f ]
+  | Many (a, b, c, d, e, f, g, l) -> a :: b :: c :: d :: e :: f :: g :: l
+
+let of_list = function
+  | [] -> Tuple0
+  | [ a ] -> Tuple1 a
+  | [ a; b ] -> Tuple2 (a, b)
+  | [ a; b; c ] -> Tuple3 (a, b, c)
+  | [ a; b; c; d ] -> Tuple4 (a, b, c, d)
+  | [ a; b; c; d; e ] -> Tuple5 (a, b, c, d, e)
+  | [ a; b; c; d; e; f ] -> Tuple6 (a, b, c, d, e, f)
+  | a :: b :: c :: d :: e :: f :: g :: l -> Many (a, b, c, d, e, f, g, l)
+
+let fold_left ~f:fn ~init = function
+  | Tuple0 -> init
+  | Tuple1 a -> fn init a
+  | Tuple2 (a, b) -> fn (fn init a) b
+  | Tuple3 (a, b, c) -> fn (fn (fn init a) b) c
+  | Tuple4 (a, b, c, d) -> fn (fn (fn (fn init a) b) c) d
+  | Tuple5 (a, b, c, d, e) -> fn (fn (fn (fn (fn init a) b) c) d) e
+  | Tuple6 (a, b, c, d, e, f) -> fn (fn (fn (fn (fn (fn init a) b) c) d) e) f
+  | Many (a, b, c, d, e, f, g, l) ->
+      List.fold_left fn (fn (fn (fn (fn (fn (fn (fn init a) b) c) d) e) f) g) l

--- a/src/small_list.mli
+++ b/src/small_list.mli
@@ -24,6 +24,7 @@ val map : f:('a -> 'b) -> 'a t -> 'b t
 val iter : f:('a -> unit) -> 'a t -> unit
 val exists : f:('a -> bool) -> 'a t -> bool
 val to_list : 'a t -> 'a list
+val of_list : 'a list -> 'a t
 val to_array : 'a t -> 'a array
 val find_map : f:('a -> 'b option) -> 'a t -> 'b option
 val fold_left : f:('acc -> 'a -> 'acc) -> init:'acc -> 'a t -> 'acc

--- a/src/small_list.mli
+++ b/src/small_list.mli
@@ -24,5 +24,6 @@ val map : f:('a -> 'b) -> 'a t -> 'b t
 val iter : f:('a -> unit) -> 'a t -> unit
 val exists : f:('a -> bool) -> 'a t -> bool
 val to_list : 'a t -> 'a list
+val to_array : 'a t -> 'a array
 val find_map : f:('a -> 'b option) -> 'a t -> 'b option
 val fold_left : f:('acc -> 'a -> 'acc) -> init:'acc -> 'a t -> 'acc

--- a/src/small_list.mli
+++ b/src/small_list.mli
@@ -1,0 +1,28 @@
+(*
+ * Copyright (c) 2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** This API has the same semantics as that of [List]. *)
+
+type +'a t
+
+val empty : _ t
+val cons : 'a -> 'a t -> 'a t
+val map : f:('a -> 'b) -> 'a t -> 'b t
+val iter : f:('a -> unit) -> 'a t -> unit
+val exists : f:('a -> bool) -> 'a t -> bool
+val to_list : 'a t -> 'a list
+val find_map : f:('a -> 'b option) -> 'a t -> 'b option
+val fold_left : f:('acc -> 'a -> 'acc) -> init:'acc -> 'a t -> 'acc

--- a/src/unix/buffer.ml
+++ b/src/unix/buffer.ml
@@ -47,4 +47,8 @@ let add_substring b s ~off ~len =
   unsafe_blit_string s off b.buffer b.position len;
   b.position <- new_position
 
+let blit ~src ~src_off ~dst ~dst_off ~len =
+  assert (src_off + len <= src.position);
+  Bytes.blit src.buffer src_off dst dst_off len
+
 let add_string b s = add_substring b s ~off:0 ~len:(String.length s)

--- a/src/unix/buffer.mli
+++ b/src/unix/buffer.mli
@@ -40,3 +40,7 @@ val add_string : t -> string -> unit
 val write_with : (string -> int -> int -> unit) -> t -> unit
 (** [write_with writer t] uses [writer] to write the contents of [t]. [writer]
     takes a string to write, an offset and a length. *)
+
+val blit : src:t -> src_off:int -> dst:bytes -> dst_off:int -> len:int -> unit
+(** [blit] copies [len] bytes from the buffer [src], starting at offset
+    [src_off], into the supplied bytes [dst], starting at offset [dst_off]. *)

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -90,6 +90,9 @@ module IO : Index.Platform.IO = struct
     if not t.readonly then
       assert (
         let total_length = t.flushed ++ Int63.of_int (Buffer.length t.buf) in
+        (* NOTE: we don't require that [end_of_value <= total_length] in order
+           to support short reads on read-write handles (see comment about this
+           case below). *)
         off <= total_length);
 
     if t.readonly || end_of_value <= t.flushed then


### PR DESCRIPTION
This implements "Suggestion 2" as described in https://github.com/mirage/index/issues/354, without adding an LRU.

Fix https://github.com/mirage/index/issues/354.