### PR TITLE
Avoid usage of `Fmt.strf`

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -864,7 +864,7 @@ struct
       ?(force = false) t =
     let merge_started = Clock.counter () in
     let merge_id = merge_counter () in
-    let msg = Fmt.strf "merge { id=%d }" merge_id in
+    let msg = Fmt.str "merge { id=%d }" merge_id in
     Semaphore.acquire msg t.merge_lock;
     let merge_lock_wait = Clock.count merge_started in
     Log.info (fun l ->

--- a/test/unix/io_array.ml
+++ b/test/unix/io_array.ml
@@ -55,7 +55,7 @@ let read_sequential () =
     let expected = mem_arr.(i) in
     let actual = IOArray.get io_arr (Int63.of_int i) in
     Alcotest.(check entry)
-      (Fmt.strf "Inserted key at index %i is accessible" i)
+      (Fmt.str "Inserted key at index %i is accessible" i)
       expected actual
   done
 
@@ -70,7 +70,7 @@ let read_sequential_prefetch () =
     let expected = mem_arr.(i) in
     let actual = IOArray.get io_arr (Int63.of_int i) in
     Alcotest.(check entry)
-      (Fmt.strf "Inserted key at index %i is accessible" i)
+      (Fmt.str "Inserted key at index %i is accessible" i)
       expected actual
   done
 

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -273,7 +273,7 @@ module Readonly = struct
 
   let readonly_clear () =
     let check_no_index_entry index k =
-      Alcotest.check_raises (Fmt.strf "Find %s key after clearing." k) Not_found
+      Alcotest.check_raises (Fmt.str "Find %s key after clearing." k) Not_found
         (fun () -> ignore_value (Index.find index k))
     in
     let* Context.{ rw; tbl; clone; _ } = Context.with_full_index () in


### PR DESCRIPTION
The recently-released `fmt.0.8.10` deprecates this function in favour of `Fmt.str`.