### PR TITLE
index: use an LRU to cache reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - The benchmarks now use `tezos-base58` instead of `tezos-context-hash` (#367)
 
+- Add an LRU to cache the result of `Index.find` operations. The default LRU
+  capacity is 30_000 entries. (#366)
+
 # 1.4.2 (2021-10-15)
 
 ## Fixed

--- a/index.opam
+++ b/index.opam
@@ -35,6 +35,7 @@ depends: [
   "alcotest" {with-test}
   "crowbar"  {with-test & >= "0.2"}
   "re"       {with-test}
+  "lru"      {>= "0.3.0"}
 ]
 synopsis: "A platform-agnostic multi-level index for OCaml"
 description:"""

--- a/src/dune
+++ b/src/dune
@@ -2,6 +2,6 @@
  (public_name index)
  (name index)
  (libraries logs fmt stdlib-shims mtime cmdliner logs.fmt logs.cli fmt.cli
-   fmt.tty jsonm progress repr ppx_repr optint)
+   fmt.tty jsonm progress repr ppx_repr optint lru)
  (preprocess
   (pps ppx_repr)))

--- a/src/index.ml
+++ b/src/index.ml
@@ -59,6 +59,40 @@ struct
 
   module Log_file = Log_file.Make (IO) (K) (V)
 
+  module Lru : sig
+    type t
+
+    val create : int -> t
+    val add : t -> key -> value -> unit
+    val find : t -> key -> value option
+    val clear : t -> unit
+  end = struct
+    module Lru =
+      Lru.M.Make
+        (K)
+        (struct
+          type t = V.t
+
+          let weight _ = 1
+        end)
+
+    type t = Lru.t ref
+
+    let create n = ref (Lru.create n)
+    let find t k = Lru.find k !t
+
+    (* NOTE: the provided [add] implementation never discards elements from the
+       LRU, and the user must manually discard any excess elements using [trim].
+       For safety, we shadow [add] with a re-implementation that always trims
+       after adding. *)
+    let add t k v =
+      let t = !t in
+      Lru.add k v t;
+      Lru.trim t
+
+    let clear t = t := Lru.create (Lru.capacity !t)
+  end
+
   module Entry = struct
     include Log_file.Entry
     module Key = K
@@ -88,6 +122,7 @@ struct
 
   type config = {
     log_size : int;  (** The log maximal size before triggering a [merge]. *)
+    lru_size : int;
     readonly : bool;
     fresh : bool;
         (** Whether the index was created from scratch, erasing existing data,
@@ -125,6 +160,7 @@ struct
             operation. It is only present when a merge is ongoing. *)
     mutable open_instances : int;
         (** The number of open instances that are shared through the [Cache.t]. *)
+    mutable lru : Lru.t;
     writer_lock : IO.Lock.t option;
         (** A lock that prevents multiple RW instances to be open at the same
             time. *)
@@ -163,6 +199,7 @@ struct
         t.generation <- Int63.succ t.generation;
         let log = Option.get t.log in
         let hook () = hook `IO_clear in
+        t.lru <- Lru.create t.config.lru_size;
         Log_file.clear ~generation:t.generation ~reopen:true ~hook log;
         Option.iter
           (fun l -> Log_file.clear ~generation:t.generation ~reopen:false l)
@@ -342,6 +379,7 @@ struct
           hook `Reload_log;
           t.generation <- h.generation;
           Log_file.close log;
+          Lru.clear t.lru;
           t.log <- try_load_log t (Layout.log ~root:t.root);
           (* The log file is never removed (even by clear). *)
           assert (t.log <> None);
@@ -419,10 +457,22 @@ struct
       find_if_exists ~name:"index" ~find:interpolation_search t.index
     in
     Semaphore.with_acquire "find_instance" t.rename_lock @@ fun () ->
-    match find_log_async () with
-    | e -> e
-    | exception Not_found -> (
-        match find_log () with e -> e | exception Not_found -> find_index ())
+    match Lru.find t.lru key with
+    | Some e ->
+        Stats.incr_nb_lru_hits ();
+        e
+    | None ->
+        Stats.incr_nb_lru_misses ();
+        let e =
+          match find_log_async () with
+          | e -> e
+          | exception Not_found -> (
+              match find_log () with
+              | e -> e
+              | exception Not_found -> find_index ())
+        in
+        Lru.add t.lru key e;
+        e
 
   let find t key =
     let t = check_open t in
@@ -463,7 +513,7 @@ struct
         IO.clear ~generation ~reopen:false log_async
 
   let v_no_cache ?(flush_callback = fun () -> ()) ~throttle ~fresh ~readonly
-      ~log_size root =
+      ?(lru_size = 30_000) ~log_size root =
     Log.debug (fun l ->
         l "[%s] not found in cache, creating a new instance"
           (Filename.basename root));
@@ -473,6 +523,7 @@ struct
     let config =
       {
         log_size = log_size * Entry.encoded_size;
+        lru_size;
         readonly;
         fresh;
         throttle;
@@ -551,6 +602,7 @@ struct
       log_async = None;
       root;
       index;
+      lru = Lru.create lru_size;
       open_instances = 1;
       merge_lock = Semaphore.make true;
       rename_lock = Semaphore.make true;
@@ -564,11 +616,12 @@ struct
   let empty_cache = Cache.create
 
   let v ?(flush_callback = fun () -> ()) ?(cache = empty_cache ())
-      ?(fresh = false) ?(readonly = false) ?(throttle = `Block_writes) ~log_size
-      root =
+      ?(fresh = false) ?(readonly = false) ?(throttle = `Block_writes)
+      ?(lru_size = 30_000) ~log_size root =
     let new_instance () =
       let instance =
-        v_no_cache ~flush_callback ~fresh ~readonly ~log_size ~throttle root
+        v_no_cache ~flush_callback ~fresh ~readonly ~log_size ~lru_size
+          ~throttle root
       in
       if readonly then sync_instance instance;
       Cache.add cache (root, readonly) instance;
@@ -932,6 +985,7 @@ struct
             match t.log_async with Some log -> log | None -> Option.get t.log
           in
           Log_file.replace log key value;
+          Lru.add t.lru key value;
           let offset = IO.offset (Log_file.io log) in
           Int63.compare offset (Int63.of_int t.config.log_size) > 0)
     in

--- a/src/index.ml
+++ b/src/index.ml
@@ -513,7 +513,7 @@ struct
         IO.clear ~generation ~reopen:false log_async
 
   let v_no_cache ?(flush_callback = fun () -> ()) ~throttle ~fresh ~readonly
-      ?(lru_size = 30_000) ~log_size root =
+      ~lru_size ~log_size root =
     Log.debug (fun l ->
         l "[%s] not found in cache, creating a new instance"
           (Filename.basename root));

--- a/src/index.ml
+++ b/src/index.ml
@@ -837,6 +837,9 @@ struct
               IO.rename ~src:merge ~dst:index.io;
               t.index <- Some index;
               t.generation <- generation;
+              (* The filter may have removed some of the bindings that exist in
+                 the LRU. We over-approximate by clearing the entire thing. *)
+              if Option.is_some filter then Lru.clear t.lru;
               Log_file.clear ~generation ~reopen:true log;
               hook `After_clear;
               let log_async = Option.get t.log_async in

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -49,6 +49,7 @@ module type S = sig
     ?fresh:bool ->
     ?readonly:bool ->
     ?throttle:[ `Overcommit_memory | `Block_writes ] ->
+    ?lru_size:int ->
     log_size:int ->
     string ->
     t
@@ -71,7 +72,10 @@ module type S = sig
         progress. [Block_writes] (the default) blocks any new writes until the
         merge is completed. [Overcommit_memory] does not block but continues to
         fill the (already full) cache.
-      @param log_size the maximum number of bindings in the `log` IO. *)
+      @param log_size the maximum number of bindings in the `log` IO.
+      @param lru_size
+        the maximum number of recently-read index bindings kept in memory.
+        Defaults to 30_000. *)
 
   val clear : t -> unit
   (** [clear t] clears [t] so that there are no more bindings in it. *)

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -55,8 +55,8 @@ let incr_nb_writes () = stats.nb_writes <- succ stats.nb_writes
 let incr_nb_merge () = stats.nb_merge <- succ stats.nb_merge
 let incr_nb_replace () = stats.nb_replace <- succ stats.nb_replace
 let incr_nb_sync () = stats.nb_sync <- succ stats.nb_sync
-let incr_nb_lru_hits () = stats.nb_sync <- succ stats.nb_sync
-let incr_nb_lru_misses () = stats.nb_sync <- succ stats.nb_sync
+let incr_nb_lru_hits () = stats.lru_hits <- succ stats.lru_hits
+let incr_nb_lru_misses () = stats.lru_misses <- succ stats.lru_misses
 
 let add_read n =
   incr_bytes_read n;

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -11,6 +11,8 @@ type t = {
   mutable replace_durations : float list;
   mutable nb_sync : int;
   mutable time_sync : float;
+  mutable lru_hits : int;
+  mutable lru_misses : int;
 }
 
 let fresh_stats () =
@@ -25,6 +27,8 @@ let fresh_stats () =
     replace_durations = [];
     nb_sync = 0;
     time_sync = 0.0;
+    lru_hits = 0;
+    lru_misses = 0;
   }
 
 let stats = fresh_stats ()
@@ -40,7 +44,9 @@ let reset_stats () =
   stats.nb_replace <- 0;
   stats.replace_durations <- [];
   stats.nb_sync <- 0;
-  stats.time_sync <- 0.0
+  stats.time_sync <- 0.0;
+  stats.lru_hits <- 0;
+  stats.lru_misses <- 0
 
 let incr_bytes_read n = stats.bytes_read <- stats.bytes_read + n
 let incr_bytes_written n = stats.bytes_written <- stats.bytes_written + n
@@ -49,6 +55,8 @@ let incr_nb_writes () = stats.nb_writes <- succ stats.nb_writes
 let incr_nb_merge () = stats.nb_merge <- succ stats.nb_merge
 let incr_nb_replace () = stats.nb_replace <- succ stats.nb_replace
 let incr_nb_sync () = stats.nb_sync <- succ stats.nb_sync
+let incr_nb_lru_hits () = stats.nb_sync <- succ stats.nb_sync
+let incr_nb_lru_misses () = stats.nb_sync <- succ stats.nb_sync
 
 let add_read n =
   incr_bytes_read n;

--- a/src/stats.mli
+++ b/src/stats.mli
@@ -11,6 +11,8 @@ type t = {
   mutable replace_durations : float list;
   mutable nb_sync : int;
   mutable time_sync : float;
+  mutable lru_hits : int;
+  mutable lru_misses : int;
 }
 (** The type for stats for an index I.
 
@@ -34,6 +36,8 @@ val add_write : int -> unit
 val incr_nb_merge : unit -> unit
 val incr_nb_replace : unit -> unit
 val incr_nb_sync : unit -> unit
+val incr_nb_lru_hits : unit -> unit
+val incr_nb_lru_misses : unit -> unit
 
 module Make (_ : Platform.CLOCK) : sig
   val start_replace : unit -> unit

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -17,6 +17,7 @@ let random_string () = String.init String_size.length (fun _i -> random_char ())
 
 module Default = struct
   let log_size = 4
+  let lru_size = 0
   let size = 103
 end
 
@@ -105,17 +106,20 @@ struct
 
   let ignore (_ : t) = ()
 
-  let empty_index ?(log_size = Default.log_size) ?flush_callback ?throttle () =
+  let empty_index ?(log_size = Default.log_size) ?(lru_size = Default.lru_size)
+      ?flush_callback ?throttle () =
     let name = fresh_name "empty_index" in
     let cache = Index.empty_cache () in
     let rw =
-      Index.v ?flush_callback ?throttle ~cache ~fresh:true ~log_size name
+      Index.v ?flush_callback ?throttle ~cache ~fresh:true ~log_size ~lru_size
+        name
     in
     let close_all = ref (fun () -> Index.close rw) in
     let tbl = Hashtbl.create 0 in
     let clone ?(fresh = false) ~readonly () =
       let t =
-        Index.v ?flush_callback ?throttle ~cache ~fresh ~log_size ~readonly name
+        Index.v ?flush_callback ?throttle ~cache ~fresh ~log_size ~lru_size
+          ~readonly name
       in
       (close_all := !close_all >> fun () -> Index.close t);
       t
@@ -123,7 +127,8 @@ struct
     { rw; tbl; clone; close_all = (fun () -> !close_all ()) }
 
   let full_index ?(size = Default.size) ?(log_size = Default.log_size)
-      ?(flush_callback = fun () -> ()) ?throttle () =
+      ?(lru_size = Default.lru_size) ?(flush_callback = fun () -> ()) ?throttle
+      () =
     let f =
       (* Disable [flush_callback] while adding initial entries *)
       ref (fun () -> ())
@@ -133,7 +138,7 @@ struct
     let rw =
       Index.v
         ~flush_callback:(fun () -> !f ())
-        ?throttle ~cache ~fresh:true ~log_size name
+        ?throttle ~cache ~fresh:true ~log_size ~lru_size name
     in
     let close_all = ref (fun () -> Index.close rw) in
     let tbl = Hashtbl.create 0 in
@@ -148,7 +153,8 @@ struct
     f := flush_callback (* Enable [flush_callback] *);
     let clone ?(fresh = false) ~readonly () =
       let t =
-        Index.v ~flush_callback ?throttle ~cache ~fresh ~log_size ~readonly name
+        Index.v ~flush_callback ?throttle ~cache ~fresh ~log_size ~lru_size
+          ~readonly name
       in
       (close_all := !close_all >> fun () -> Index.close t);
       t
@@ -160,11 +166,15 @@ struct
     t.close_all ();
     a
 
-  let with_empty_index ?log_size ?flush_callback ?throttle () f =
-    call_then_close (empty_index ?log_size ?flush_callback ?throttle ()) f
+  let with_empty_index ?log_size ?lru_size ?flush_callback ?throttle () f =
+    call_then_close
+      (empty_index ?log_size ?lru_size ?flush_callback ?throttle ())
+      f
 
-  let with_full_index ?log_size ?flush_callback ?throttle ?size () f =
-    call_then_close (full_index ?log_size ?flush_callback ?throttle ?size ()) f
+  let with_full_index ?log_size ?lru_size ?flush_callback ?throttle ?size () f =
+    call_then_close
+      (full_index ?log_size ?lru_size ?flush_callback ?throttle ?size ())
+      f
 end
 
 let ( let* ) f k = f k

--- a/test/unix/common.ml
+++ b/test/unix/common.ml
@@ -25,6 +25,7 @@ module Key = struct
   include Index.Key.String_fixed (String_size)
 
   let v = random_string
+  let pp = Fmt.Dump.string
 end
 
 module Value = struct
@@ -32,6 +33,7 @@ module Value = struct
 
   let v = random_string
   let equal = String.equal
+  let pp = Fmt.Dump.string
 end
 
 type binding = Key.t * Value.t

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -15,12 +15,14 @@ module Key : sig
   include Index.Key.S with type t = string
 
   val v : unit -> t
+  val pp : t Fmt.t
 end
 
 module Value : sig
   include Index.Value.S with type t = string
 
   val v : unit -> t
+  val pp : t Fmt.t
 end
 
 module Tbl : sig

--- a/test/unix/common.mli
+++ b/test/unix/common.mli
@@ -66,6 +66,7 @@ end) : sig
 
   val with_empty_index :
     ?log_size:int ->
+    ?lru_size:int ->
     ?flush_callback:(unit -> unit) ->
     ?throttle:[ `Overcommit_memory | `Block_writes ] ->
     unit ->
@@ -76,6 +77,7 @@ end) : sig
 
   val with_full_index :
     ?log_size:int ->
+    ?lru_size:int ->
     ?flush_callback:(unit -> unit) ->
     ?throttle:[ `Overcommit_memory | `Block_writes ] ->
     ?size:int ->

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -1057,6 +1057,7 @@ let () =
       ("io_array", Io_array.tests);
       ("merge", Force_merge.tests);
       ("live", Live.tests);
+      ("lru", Test_lru.tests);
       ("on restart", DuplicateInstance.tests);
       ("readonly", Readonly.tests);
       ("close", Close.tests);

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -943,6 +943,7 @@ module Filter = struct
     let (_ : Value.t) = Index.find rw k in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));
+    Index.check_not_found rw k;
     check_equivalence rw tbl
 
   (** Test that the results of [filter] are propagated to a clone which was

--- a/test/unix/main.ml
+++ b/test/unix/main.ml
@@ -276,7 +276,11 @@ module Readonly = struct
       Alcotest.check_raises (Fmt.str "Find %s key after clearing." k) Not_found
         (fun () -> ignore_value (Index.find index k))
     in
-    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; clone; _ } =
+      (* Ensure that the clear also wipes the LRU *)
+      let lru_size = 10 in
+      Context.with_full_index ~lru_size ()
+    in
     let ro = clone ~readonly:true () in
     Index.clear rw;
     Index.sync ro;
@@ -915,23 +919,28 @@ end
 
 (* Tests of {Index.filter} *)
 module Filter = struct
+  (* Filtering should also affect the in-memory LRU. *)
+  let lru_size = 10
+
   (** Test that all bindings are kept when using [filter] with a true predicate. *)
   let filter_none () =
-    let* Context.{ rw; tbl; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; _ } = Context.with_full_index ~lru_size () in
     Index.filter rw (fun _ -> true);
     check_equivalence rw tbl
 
   (** Test that all bindings are removed when using [filter] with a false
       predicate. *)
   let filter_all () =
-    let* Context.{ rw; _ } = Context.with_full_index () in
+    let* Context.{ rw; _ } = Context.with_full_index ~lru_size () in
     Index.filter rw (fun _ -> false);
     check_equivalence rw (Hashtbl.create 0)
 
   (** Test that [filter] can be used to remove exactly a single binding. *)
   let filter_one () =
-    let* Context.{ rw; tbl; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; _ } = Context.with_full_index ~lru_size () in
     let k = random_existing_key tbl in
+    (* Ensure the key is cached in the LRU: [filter] must remove it from there too. *)
+    let (_ : Value.t) = Index.find rw k in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));
     check_equivalence rw tbl
@@ -939,7 +948,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created before. *)
   let clone_then_filter () =
-    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index ~lru_size () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     let rw2 = clone ~readonly:false () in
@@ -950,7 +959,7 @@ module Filter = struct
   (** Test that the results of [filter] are propagated to a clone which was
       created after. *)
   let filter_then_clone () =
-    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index ~lru_size () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));
@@ -961,7 +970,7 @@ module Filter = struct
   (** Test that using [filter] doesn't affect fresh clones created later at the
       same path. *)
   let empty_after_filter_and_fresh () =
-    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index () in
+    let* Context.{ rw; tbl; clone; _ } = Context.with_full_index ~lru_size () in
     let k = random_existing_key tbl in
     Hashtbl.remove tbl k;
     Index.filter rw (fun (k', _) -> not (String.equal k k'));

--- a/test/unix/test_lru.ml
+++ b/test/unix/test_lru.ml
@@ -1,0 +1,125 @@
+(** Tests of the in-memory LRU used by the Index implementation.
+
+    NOTE: most other tests in the suite set an LRU size of 0 for simplicity. *)
+
+module Stats = Index.Stats
+open Common
+
+module Context = Common.Make_context (struct
+  let root = Filename.concat "_tests" "test_log_with_lru"
+end)
+
+let check_bool pos ~expected act = Alcotest.(check ~pos bool) "" expected act
+let check_int pos ~expected act = Alcotest.(check ~pos int) "" expected act
+
+let check_value pos ~expected act =
+  let key = Alcotest.testable Key.pp Key.equal in
+  Alcotest.(check ~pos key) "" expected act
+
+let check_lru_stats pos ~hits ~misses =
+  Alcotest.(check ~pos int) "LRU hits" hits Stats.((get ()).lru_hits);
+  Alcotest.(check ~pos int) "LRU misses" misses Stats.((get ()).lru_misses)
+
+let get_new_cached_binding idx =
+  let k, v = (Key.v (), Value.v ()) in
+  Index.replace idx k v;
+  check_value __POS__ ~expected:v (Index.find idx k);
+  (k, v)
+
+let test_replace_and_find () =
+  let lru_size = 1 in
+  let* { rw = idx; _ } = Context.with_empty_index ~lru_size () in
+
+  (* Check that [replace] populates the LRU: *)
+  let k1, v1 = (Key.v (), Value.v ()) in
+  let () =
+    Stats.reset_stats ();
+    Index.replace idx k1 v1;
+    (* [k1] is now in the LRU: *)
+    check_value __POS__ ~expected:v1 (Index.find idx k1);
+    check_lru_stats __POS__ ~hits:1 ~misses:0
+  in
+
+  (* Check that a second [replace] updates the LRU contents: *)
+  let k2, v2 = (Key.v (), Value.v ()) in
+  let () =
+    assert (k1 <> k2);
+    Stats.reset_stats ();
+    Index.replace idx k2 v2;
+    (* [k2] has replaced [k1] in the LRU, so we miss on [find k1]: *)
+    check_value __POS__ ~expected:v1 (Index.find idx k1);
+    check_lru_stats __POS__ ~hits:0 ~misses:1;
+    (* [k1] is now in the LRU: *)
+    check_value __POS__ ~expected:v1 (Index.find idx k1);
+    check_lru_stats __POS__ ~hits:1 ~misses:1
+  in
+  ()
+
+let test_mem () =
+  let lru_size = 1 in
+  let* { rw = idx; _ } = Context.with_empty_index ~lru_size () in
+
+  (* Initially, [k2] is in the LRU and [k1] is not: *)
+  let k1, k2, v1, v2 = (Key.v (), Key.v (), Value.v (), Value.v ()) in
+  Index.replace idx k1 v1;
+  Index.replace idx k2 v2;
+
+  (* [mem k2] hits in the LRU: *)
+  let () =
+    Stats.reset_stats ();
+    check_bool __POS__ ~expected:true (Index.mem idx k2);
+    check_lru_stats __POS__ ~hits:1 ~misses:0
+  in
+
+  (* [mem k1] initially misses in the LRU, but subsequent calls hit in the LRU
+     (because the [k2] binding is replaced by [k1] on the miss). *)
+  let () =
+    Stats.reset_stats ();
+    check_bool __POS__ ~expected:true (Index.mem idx k1);
+    check_lru_stats __POS__ ~hits:0 ~misses:1;
+    check_bool __POS__ ~expected:true (Index.mem idx k1);
+    check_lru_stats __POS__ ~hits:1 ~misses:1
+  in
+  ()
+
+(* Check that the LRU is cleared on [clear]. *)
+let test_clear () =
+  let lru_size = 1 in
+  let* { rw = idx; _ } = Context.with_full_index ~lru_size () in
+
+  (* Add a binding and ensure that it's in the LRU: *)
+  let k, v = (Key.v (), Value.v ()) in
+  Index.replace idx k v;
+  check_value __POS__ ~expected:v (Index.find idx k);
+
+  (* We should miss in the LRU when attempting to find [k] after [clear]: *)
+  Index.clear idx;
+  Stats.reset_stats ();
+  Alcotest.check_raises "find after clear" Not_found (fun () ->
+      ignore (Index.find idx k));
+  check_lru_stats __POS__ ~hits:0 ~misses:1
+
+(* Check that bindings in the LRU are properly removed by [filter]: *)
+let test_filter () =
+  let lru_size = 1 in
+  let* { rw = idx; _ } = Context.with_full_index ~lru_size () in
+
+  (* Add a binding and ensure that it's in the LRU: *)
+  let k, v = (Key.v (), Value.v ()) in
+  Index.replace idx k v;
+  check_value __POS__ ~expected:v (Index.find idx k);
+
+  (* Remove [k] from the index via [filter], then try to [find] it: *)
+  Index.filter idx (fun (k', _) -> not (Key.equal k k'));
+  Stats.reset_stats ();
+  Alcotest.check_raises ~pos:__POS__ "find after filter-false" Not_found
+    (fun () -> ignore (Index.find idx k));
+  check_lru_stats __POS__ ~hits:0 ~misses:1
+
+let tests =
+  [
+    ("replace_and_find", `Quick, test_replace_and_find);
+    ("mem", `Quick, test_mem);
+    ("clear", `Quick, test_clear);
+    ("filter", `Quick, test_filter);
+  ]


### PR DESCRIPTION
Fix https://github.com/mirage/index/issues/359.

Following the recent change to the log-file implementation, successful reads of the index must always read from disk (because even log file entries are not kept entirely in memory). This traded some speed performance in favour of much lower memory usage.

For workflows with temporal locality, it's possible to recover some of this speed by adding a relatively small LRU to cache `find`s from disk. This is implemented by this commit.

**TODO**:
- [x] set the LRU size to be 0 in some of the existing tests that expect to exercise the log and data IO (right now, the tests have been weakened by having most `find`s go via the LRU).
- [x] and add some new tests that check the operation of the LRU specifically.