### PR TITLE
Upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
-version = 0.19.0
+version = 0.20.0
+ocaml-version = 4.08
 profile = conventional
 
 break-infix = fit-or-vertical

--- a/test/cli/generate.ml
+++ b/test/cli/generate.ml
@@ -8,10 +8,8 @@ let random () =
 
 module Index =
   Index_unix.Make
-    (Index.Key.String_fixed
-       (Size))
-       (Index.Value.String_fixed (Size))
-       (Index.Cache.Noop)
+    (Index.Key.String_fixed (Size)) (Index.Value.String_fixed (Size))
+    (Index.Cache.Noop)
 
 let random () =
   let index = Index.v ~fresh:true ~log_size:100 "data/random" in

--- a/test/cli/index_fsck.ml
+++ b/test/cli/index_fsck.ml
@@ -4,9 +4,7 @@ end
 
 module Index =
   Index_unix.Make
-    (Index.Key.String_fixed
-       (Size))
-       (Index.Value.String_fixed (Size))
-       (Index.Cache.Noop)
+    (Index.Key.String_fixed (Size)) (Index.Value.String_fixed (Size))
+    (Index.Cache.Noop)
 
 let () = match Index.Checks.cli () with _ -> .


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.

The changes are due to an improvement of the formatting of functor arguments.