### PR TITLE
Fix OCamlformat option ordering

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,7 @@
 version = 0.20.0
-ocaml-version = 4.08
 profile = conventional
 
+ocaml-version = 4.08
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters = no


### PR DESCRIPTION
`ocaml-version` must come after `profile`, since the `profile` option resets all options to the profile defaults.

See https://github.com/mirage/irmin/pull/1556#issuecomment-1019929899.