### PR TITLE
Expose Index.v_no_cache

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -622,8 +622,8 @@ struct
 
   (* Defaults shared between {!v} and {!v_no_cache}. *)
   module D = struct
-    let flush_callback,fresh,readonly,throttle,lru_size = 
-      (fun () -> ()),false,false,`Block_writes,30_000
+    let flush_callback, fresh, readonly, throttle, lru_size =
+      ((fun () -> ()), false, false, `Block_writes, 30_000)
   end
 
   let v ?(flush_callback = D.flush_callback) ?(cache = empty_cache ())
@@ -667,13 +667,13 @@ struct
   (* As {!v_no_cache} (i.e., avoiding any internal instance caching), but we need to
      return a reference to an option. This always returns ref (Some _). For the optional
      args, we try to match exactly {!v} above. *)
-  let v_no_cache 
-      ?(flush_callback = D.flush_callback)
-      ?(fresh = D.fresh) ?(readonly = D.readonly) ?(throttle = D.throttle)
-      ?(lru_size = D.lru_size) ~log_size root : t =
-    let x : instance = 
-      v_no_cache ~flush_callback ~throttle ~fresh ~readonly ~lru_size ~log_size root 
-    in    
+  let v_no_cache ?(flush_callback = D.flush_callback) ?(fresh = D.fresh)
+      ?(readonly = D.readonly) ?(throttle = D.throttle) ?(lru_size = D.lru_size)
+      ~log_size root : t =
+    let x : instance =
+      v_no_cache ~flush_callback ~throttle ~fresh ~readonly ~lru_size ~log_size
+        root
+    in
     ref (Some x)
 
   (** {1 Merges} *)

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -77,6 +77,18 @@ module type S = sig
         the maximum number of recently-read index bindings kept in memory.
         Defaults to 30_000. *)
 
+  val v_no_cache: 
+    ?flush_callback:(unit -> unit) ->
+    ?fresh:bool ->
+    ?readonly:bool ->
+    ?throttle:[ `Overcommit_memory | `Block_writes ] ->
+    ?lru_size:int ->
+    log_size:int ->
+    string ->
+    t
+  (** As {!v}, but without any caching; this is needed for layers (for example), where we
+     always want to open a new instance, and any sharing would lead to problems. *)
+
   val clear : t -> unit
   (** [clear t] clears [t] so that there are no more bindings in it. *)
 

--- a/src/index_intf.ml
+++ b/src/index_intf.ml
@@ -77,7 +77,7 @@ module type S = sig
         the maximum number of recently-read index bindings kept in memory.
         Defaults to 30_000. *)
 
-  val v_no_cache: 
+  val v_no_cache :
     ?flush_callback:(unit -> unit) ->
     ?fresh:bool ->
     ?readonly:bool ->
@@ -86,8 +86,9 @@ module type S = sig
     log_size:int ->
     string ->
     t
-  (** As {!v}, but without any caching; this is needed for layers (for example), where we
-     always want to open a new instance, and any sharing would lead to problems. *)
+  (** As {!v}, but without any caching; this is needed for layers (for example),
+      where we always want to open a new instance, and any sharing would lead to
+      problems. *)
 
   val clear : t -> unit
   (** [clear t] clears [t] so that there are no more bindings in it. *)


### PR DESCRIPTION
This is needed by layers for example, where in the worker we need to open a new irmin
pack+index, making sure we DO NOT reuse any existing instances.

I was never sure why there were caches baked in to the constructors of index and irmin pack stores in the first place, so please let me know if somehow this breaks some invariants I am not aware of.

The next step is to then add a similar constructor to irmin pack stores.