### PR TITLE
Make index-bench bench executable private

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 - Support all version of cmdliner (#386)
 
+## Fixed
+
+- Make `index-bench`'s `bench` executable private, avoiding executable
+  name collisions in opam-monorepo projects. (#389, @NathanReb)
+
 # 1.6.0 (2022-02-12)
 
 ## Added

--- a/bench/dune
+++ b/bench/dune
@@ -4,9 +4,8 @@
  (libraries progress logs fmt mtime mtime.clock.os))
 
 (executable
- (public_name bench)
+ (name bench)
  (modules bench)
- (package index-bench)
  (preprocess
   (pps ppx_repr ppx_deriving_yojson))
  (libraries index index.unix cmdliner metrics metrics-unix yojson fmt re


### PR DESCRIPTION
Fixes #388 

As discussed with @icristescu and @Ngoguey42, the package is not meant to be used by external users nor is running the benchmark so we agreed that making it private was the right move here.