### PR TITLE
Remove unecessary upper bound on cmdliner

### DIFF
--- a/index.opam
+++ b/index.opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner" {< "1.1.0"}
+  "cmdliner"
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"


### PR DESCRIPTION
This is not required anymore since #386!