### PR TITLE
Open lock files with O_CLOEXEC flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changed
+
+- Lock files are now opened with O_CLOEXEC flag (#394, @vect0r-vicall)
+
 # 1.6.2 (2023-06-06)
 
 ## Changed

--- a/src/unix/index_unix.ml
+++ b/src/unix/index_unix.ml
@@ -304,7 +304,8 @@ module IO : Index.Platform.IO = struct
 
     let unsafe_lock op f =
       mkdir (Filename.dirname f);
-      let fd = Unix.openfile f [ Unix.O_CREAT; Unix.O_RDWR ] 0o600
+      let fd =
+        Unix.openfile f [ Unix.O_CREAT; Unix.O_RDWR; Unix.O_CLOEXEC ] 0o600
       and pid = string_of_int (Unix.getpid ()) in
       let pid_len = String.length pid in
       try


### PR DESCRIPTION
This simple PR aims to open lock files with the `Unix.O_CLOEXEC` flag to avoid resource leak in case of forks.