### PR TITLE
tests/unix: add `logs.threaded` as a dependency

### DIFF
--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,5 +1,5 @@
 (tests
  (names main force_merge io_array)
  (package index)
- (libraries index index.unix unix alcotest fmt logs logs.fmt re stdlib-shims
-   threads.posix repr semaphore-compat optint mtime.clock.os))
+ (libraries index index.unix unix alcotest fmt logs logs.fmt logs.threaded re
+   stdlib-shims threads.posix repr semaphore-compat optint mtime.clock.os))


### PR DESCRIPTION
- The upcoming release of logs.0.8.0 (https://github.com/ocaml/opam-repository/pull/27602) installs `logs.threaded` in `<dst-dir>/logs/threaded`
- Previously the tests in `tests/unix` would only find this library by chance, since `logs_threaded.cm*` was installed in the same directory as the `logs` library