### PR TITLE
Update for cmdliner.2.0.0

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -558,10 +558,10 @@ let env_var s = Cmd.Env.info ("INDEX_BENCH_" ^ s)
 let new_file =
   let parse s =
     match Sys.file_exists s && Sys.is_directory s with
-    | false -> `Ok s
-    | true -> `Error (Printf.sprintf "Error: `%s' is a directory" s)
+    | false -> Ok s
+    | true -> Error (`Msg (Printf.sprintf "Error: `%s' is a directory" s))
   in
-  (parse, Format.pp_print_string)
+  Arg.conv (parse, Format.pp_print_string)
 
 let regex =
   let parse s =

--- a/bench/dune
+++ b/bench/dune
@@ -8,8 +8,8 @@
  (modules bench)
  (preprocess
   (pps ppx_repr ppx_deriving_yojson))
- (libraries index index.unix cmdliner metrics metrics-unix yojson fmt re
-   stdlib-shims common mtime mtime.clock.os unix))
+ (libraries index index.unix cmdliner metrics metrics-unix yojson fmt fmt.tty
+   re stdlib-shims common mtime mtime.clock.os unix))
 
 (alias
  (name bench)
@@ -26,7 +26,8 @@
  (preprocess
   (pps ppx_repr))
  (libraries index index.unix unix cmdliner logs repr ppx_repr common
-   tezos-base58 optint fmt rusage mtime mtime.clock.os digestif))
+   tezos-base58 optint fmt fmt.tty rusage mtime mtime.clock.os digestif
+   digestif.c))
 
 ;; Require the above executables to compile during tests
 

--- a/index-bench.opam
+++ b/index-bench.opam
@@ -22,7 +22,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "progress" {>= "0.2.1"}
   "tezos-base58" {>= "1.0.0" & with-test}
-  "digestif" {>= "0.7" & with-test}
+  "digestif" {>= "1.0.0" & with-test}
   "optint" {>= "0.1.0" & with-test}
   "repr" {>= "0.2.1" & with-test}
   "rusage" {>= "1.0.0" & with-test}

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,5 +1,6 @@
 (tests
  (names main force_merge io_array)
  (package index)
- (libraries index index.unix unix alcotest fmt logs logs.fmt logs.threaded re
-   stdlib-shims threads.posix repr semaphore-compat optint mtime.clock.os))
+ (libraries index index.unix unix alcotest fmt fmt.tty logs logs.fmt
+   logs.threaded re stdlib-shims threads.posix repr semaphore-compat optint
+   mtime.clock.os))


### PR DESCRIPTION
Fix https://github.com/mirage/index/issues/401 (and a few other dependency names in dune files)